### PR TITLE
Refactoring/dataset creation use case

### DIFF
--- a/DataSetExplorer/DataSetBuilder/Model/Annotator.cs
+++ b/DataSetExplorer/DataSetBuilder/Model/Annotator.cs
@@ -4,9 +4,9 @@ namespace DataSetExplorer.DataSetBuilder.Model
 {
     public class Annotator
     {
-        public int Id { get; set; }
-        public int YearsOfExperience { get; set; }
-        public int Ranking { get; set; }
+        public int Id { get; }
+        public int YearsOfExperience { get; }
+        public int Ranking { get; }
 
         public Annotator(int id)
         {

--- a/DataSetExplorer/DataSetBuilder/Model/DataSet.cs
+++ b/DataSetExplorer/DataSetBuilder/Model/DataSet.cs
@@ -18,7 +18,7 @@ namespace DataSetExplorer.DataSetBuilder.Model
         {
             foreach (var instance in instances)
             {
-                if (_instances.TryGetValue(instance, out DataSetInstance existingInstance))
+                if (_instances.TryGetValue(instance, out var existingInstance))
                 {
                     existingInstance.AddAnnotations(instance);
                 } else

--- a/DataSetExplorer/DataSetBuilder/Model/DataSetAnnotation.cs
+++ b/DataSetExplorer/DataSetBuilder/Model/DataSetAnnotation.cs
@@ -8,7 +8,7 @@ namespace DataSetExplorer.DataSetBuilder.Model
         public CodeSmell InstanceSmell { get; }
         public int Severity { get; }
         public List<SmellHeuristic> ApplicableHeuristics { get; }
-        public Annotator Annotator { get; set; }
+        public Annotator Annotator { get; internal set; }
 
         public DataSetAnnotation(string instanceSmell, int severity, Annotator annotator, List<SmellHeuristic> applicableHeuristics)
         {

--- a/DataSetExplorer/DataSetBuilder/Model/DataSetAnnotation.cs
+++ b/DataSetExplorer/DataSetBuilder/Model/DataSetAnnotation.cs
@@ -8,7 +8,7 @@ namespace DataSetExplorer.DataSetBuilder.Model
         public CodeSmell InstanceSmell { get; }
         public int Severity { get; }
         public List<SmellHeuristic> ApplicableHeuristics { get; }
-        public Annotator Annotator { get; internal set; }
+        public Annotator Annotator { get; set; }
 
         public DataSetAnnotation(string instanceSmell, int severity, Annotator annotator, List<SmellHeuristic> applicableHeuristics)
         {

--- a/DataSetExplorer/DataSetBuilder/Model/DataSetInstance.cs
+++ b/DataSetExplorer/DataSetBuilder/Model/DataSetInstance.cs
@@ -12,7 +12,7 @@ namespace DataSetExplorer.DataSetBuilder.Model
         public string ProjectLink { get; }
         public SnippetType Type { get; }
         public ISet<DataSetAnnotation> Annotations { get; }
-        public Dictionary<CaDETMetric, double> MetricFeatures { get; set; } // TODO: Expand and replace with the IFeature if a new feature type is introduced
+        public Dictionary<CaDETMetric, double> MetricFeatures { get; internal set; } // TODO: Expand and replace with the IFeature if a new feature type is introduced
 
         internal DataSetInstance(string codeSnippetId, string link, string projectLink, SnippetType type, Dictionary<CaDETMetric, double> metricFeatures)
         {

--- a/DataSetExplorer/DataSetCreationService.cs
+++ b/DataSetExplorer/DataSetCreationService.cs
@@ -1,0 +1,59 @@
+﻿using DataSetExplorer.DataSetBuilder;
+using DataSetExplorer.DataSetBuilder.Model;
+using DataSetExplorer.DataSetSerializer;
+using DataSetExplorer.DataSetSerializer.ViewModel;
+using DataSetExplorer.RepositoryAdapters;
+using FluentResults;
+using System;
+using System.IO;
+
+namespace DataSetExplorer
+{
+    public class DataSetCreationService : IDataSetCreator
+    {
+        private readonly ICodeRepository _codeRepository;
+        private readonly string _basePath;
+
+        public DataSetCreationService(string basePath, ICodeRepository codeRepository)
+        {
+            _basePath = basePath;
+            _codeRepository = codeRepository;
+        }
+
+        public Result<string> CreateDataSetSpreadsheet(string projectName, string projectAndCommitUrl)
+        {
+            return CreateDataSetSpreadsheet(projectName, projectAndCommitUrl, new NewSpreadSheetColumnModel());
+        }
+
+        public Result<string> CreateDataSetSpreadsheet(string projectName, string projectAndCommitUrl, NewSpreadSheetColumnModel columnModel)
+        {
+            //TODO: Once we establish some DB, we can have the export to excel operation be separate from the "CreateDataSet"
+            var gitFolderPath = _basePath + projectName + Path.DirectorySeparatorChar + "git";
+            _codeRepository.SetupRepository(projectAndCommitUrl, gitFolderPath);
+            
+            var dataSet = CreateDataSetFromRepository(projectAndCommitUrl, gitFolderPath);
+            var excelFileName = ExportToExcel(projectName, columnModel, dataSet);
+            
+            return Result.Ok(excelFileName);
+        }
+
+        private static DataSet CreateDataSetFromRepository(string projectAndCommitUrl, string projectPath)
+        {
+            //TODO: Introduce Director as a separate class and insert through DI.
+            var builder = new CaDETToDataSetBuilder(projectAndCommitUrl, projectPath);
+            return builder.IncludeMembersWith(10).IncludeClassesWith(3, 5)
+                .RandomizeClassSelection().RandomizeMemberSelection()
+                .SetProjectExtractionPercentile(10).Build();
+        }
+        private string ExportToExcel(string projectName, NewSpreadSheetColumnModel columnModel, DataSet dataSet)
+        {
+            var sheetFolderPath = _basePath + projectName + Path.DirectorySeparatorChar + "sheets" + Path.DirectorySeparatorChar;
+            if(!Directory.Exists(sheetFolderPath)) Directory.CreateDirectory(sheetFolderPath);
+            var exporter = new NewDataSetExporter(sheetFolderPath, columnModel);
+
+            var fileName = DateTime.Now.ToString("yyyy-MM-dd--HH-mm-ss");
+            exporter.Export(dataSet, fileName);
+            return fileName;
+        }
+    }
+}

--- a/DataSetExplorer/DataSetExplorer.csproj
+++ b/DataSetExplorer/DataSetExplorer.csproj
@@ -7,6 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="EPPlus" Version="5.6.3" />
+    <PackageReference Include="FluentResults" Version="2.5.0" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DataSetExplorer/DataSetSerializer/NewDataSetExporter.cs
+++ b/DataSetExplorer/DataSetSerializer/NewDataSetExporter.cs
@@ -13,12 +13,12 @@ namespace DataSetExplorer.DataSetSerializer
         private readonly string _exportPath;
         //TODO: ColumnHeuristicsModel should be repurposed as some kind of HeuristicCatalog and put into the domain layer
         private readonly ColumnHeuristicsModel _requiredSmells;
-        private bool _includeMetrics;
-        public NewDataSetExporter(string exportPath, ColumnHeuristicsModel smells, bool includeMetrics)
+        private readonly bool _includeMetrics;
+        public NewDataSetExporter(string exportPath, NewSpreadSheetColumnModel columnModel)
         {
             _exportPath = exportPath;
-            _requiredSmells = smells;
-            _includeMetrics = includeMetrics;
+            _requiredSmells = columnModel.SmellsAndHeuristics;
+            _includeMetrics = columnModel.IncludeMetrics;
         }
         public void Export(DataSet project, string fileName)
         {

--- a/DataSetExplorer/DataSetSerializer/ViewModel/NewSpreadSheetColumnModel.cs
+++ b/DataSetExplorer/DataSetSerializer/ViewModel/NewSpreadSheetColumnModel.cs
@@ -1,0 +1,18 @@
+﻿namespace DataSetExplorer.DataSetSerializer.ViewModel
+{
+    public class NewSpreadSheetColumnModel
+    {
+        public ColumnHeuristicsModel SmellsAndHeuristics { get; }
+        public bool IncludeMetrics { get; }
+
+        public NewSpreadSheetColumnModel(ColumnHeuristicsModel smellsAndHeuristics, bool includeMetrics)
+        {
+            SmellsAndHeuristics = smellsAndHeuristics;
+            IncludeMetrics = includeMetrics;
+        }
+
+        public NewSpreadSheetColumnModel(): this(new ColumnHeuristicsModel(), false)
+        {
+        }
+    }
+}

--- a/DataSetExplorer/IDataSetCreator.cs
+++ b/DataSetExplorer/IDataSetCreator.cs
@@ -1,0 +1,11 @@
+﻿using DataSetExplorer.DataSetSerializer.ViewModel;
+using FluentResults;
+
+namespace DataSetExplorer
+{
+    public interface IDataSetCreator
+    {
+        public Result<string> CreateDataSetSpreadsheet(string projectName, string projectAndCommitUrl);
+        public Result<string> CreateDataSetSpreadsheet(string projectName, string projectAndCommitUrl, NewSpreadSheetColumnModel columnModel);
+    }
+}

--- a/DataSetExplorer/Program.cs
+++ b/DataSetExplorer/Program.cs
@@ -9,36 +9,21 @@ using System.Linq;
 using CodeModel;
 using CodeModel.CaDETModel;
 using CodeModel.CaDETModel.CodeItems;
+using DataSetExplorer.RepositoryAdapters;
 
 namespace DataSetExplorer
 {
     class Program
     {
-        /*
-         *https://github.com/jellyfin/jellyfin/tree/6c2eb5fc7e872a29b4a0951849681ae0764dbb8e
-9.5k Zvezda I 20k commitova
-
-https://github.com/MonoGame/MonoGame/tree/4802d00db04dc7aa5fe07cd2d908f9a4b090a4fd
-7.3k Zvezda I 13k commitova
-
-https://github.com/ppy/osu/tree/2cac373365309a40474943f55c56159ed8f9433c
-6.2k Zvezda, 37k commitova
-
-https://github.com/ThreeMammals/Ocelot/tree/3ef6abd7465fc77632e4b2d5189fbbf47b457867
-6k Zvezda, 1.2k commita
-
-https://github.com/dotnet/machinelearning/tree/44660297b4238a4f3e843bd071f5e8b214bdd38a
-
-         *
-         */
         static void Main(string[] args)
         {
-            //MakeExcelFromProjectUseCase();
+            IDataSetCreator service = new DataSetCreationService("C:\\main-repository\\", new GitCodeRepository());
+            service.CreateDataSetSpreadsheet("MyProject",
+                "https://github.com/wieslawsoltes/Core2D/tree/50ea0849bef7e211500764ffcd1fece4a3cb224e");
             //FindInstancesRequiringAdditionalAnnotationUseCase();
             //FindInstancesWithAllDisagreeingAnnotationsUseCase();
             //ExportAnnotatedDataSet();
             //CheckAnnotationConsistencyForAnnotator(1);
-            CheckAnnotationConsistencyBetweenAnnotatorsForSeverity(1);
         }
 
         private static void CheckAnnotationConsistencyBetweenAnnotatorsForSeverity(int severity)
@@ -185,20 +170,5 @@ https://github.com/dotnet/machinelearning/tree/44660297b4238a4f3e843bd071f5e8b21
             return importer.Import("Clean CaDET");
         }
 
-        private static void MakeExcelFromProjectUseCase()
-        {
-            var dataSet = CreateDataSetFromRepository(
-                "https://github.com/MonoGame/MonoGame/tree/4802d00db04dc7aa5fe07cd2d908f9a4b090a4fd",
-                "C:/sdataset-p2/MonoGame");
-            var exporter = new NewDataSetExporter("C:/DSOutput/", new ColumnHeuristicsModel(), false);
-            exporter.Export(dataSet, "MonoGame");
-        }
-
-        private static DataSet CreateDataSetFromRepository(string projectAndCommitUrl, string projectPath)
-        {
-            var builder = new CaDETToDataSetBuilder(projectAndCommitUrl, projectPath);
-            return builder.IncludeMembersWith(10).IncludeClassesWith(3, 5).RandomizeClassSelection().RandomizeMemberSelection()
-              .SetProjectExtractionPercentile(10).Build();
-        }
     }
 }

--- a/DataSetExplorer/Program.cs
+++ b/DataSetExplorer/Program.cs
@@ -169,6 +169,5 @@ namespace DataSetExplorer
             var importer = new ExcelImporter(folder);
             return importer.Import("Clean CaDET");
         }
-
     }
 }

--- a/DataSetExplorer/RepositoryAdapters/GitCodeRepository.cs
+++ b/DataSetExplorer/RepositoryAdapters/GitCodeRepository.cs
@@ -1,0 +1,49 @@
+﻿using LibGit2Sharp;
+using System.IO;
+
+namespace DataSetExplorer.RepositoryAdapters
+{
+    public class GitCodeRepository : ICodeRepository
+    {
+        public void CloneRepository(string url, string projectPath)
+        {
+            if(Directory.Exists(projectPath)) DeleteDirectory(projectPath);
+            Directory.CreateDirectory(projectPath);
+            Repository.Clone(url, projectPath);
+        }
+
+        public void CheckoutCommit(string commitHash, string projectPath)
+        {
+            Commands.Checkout(new Repository(projectPath), commitHash);
+        }
+
+        public void SetupRepository(string urlWithCommitHash, string projectPath)
+        {
+            var urlParts = urlWithCommitHash.Split("/tree/");
+            var projectUrl = urlParts[0] + ".git";
+            CloneRepository(projectUrl, projectPath);
+
+            var commitHash = urlParts[1];
+            CheckoutCommit(commitHash, projectPath);
+        }
+
+        private static void DeleteDirectory(string directory)
+        {
+            foreach (var subDirectory in Directory.EnumerateDirectories(directory))
+            {
+                DeleteDirectory(subDirectory);
+            }
+
+            foreach (var fileName in Directory.EnumerateFiles(directory))
+            {
+                var fileInfo = new FileInfo(fileName)
+                {
+                    Attributes = FileAttributes.Normal
+                };
+                fileInfo.Delete();
+            }
+
+            Directory.Delete(directory);
+        }
+    }
+}

--- a/DataSetExplorer/RepositoryAdapters/ICodeRepository.cs
+++ b/DataSetExplorer/RepositoryAdapters/ICodeRepository.cs
@@ -1,0 +1,9 @@
+﻿namespace DataSetExplorer.RepositoryAdapters
+{
+    public interface ICodeRepository
+    {
+        void CloneRepository(string url, string projectPath);
+        void CheckoutCommit(string commitHash, string projectPath);
+        void SetupRepository(string urlWithCommitHash, string projectPath);
+    }
+}

--- a/DataSetExplorerTests/Integration/GitRepositoryTests.cs
+++ b/DataSetExplorerTests/Integration/GitRepositoryTests.cs
@@ -1,0 +1,55 @@
+﻿using DataSetExplorer.RepositoryAdapters;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace DataSetExplorer.Tests.Integration
+{
+    public class GitRepositoryTests
+    {
+        private readonly char _separator = Path.DirectorySeparatorChar;
+
+        [Fact]
+        public void Clones_repository()
+        {
+            ICodeRepository gitAdapter = new GitCodeRepository();
+
+            gitAdapter.CloneRepository("https://github.com/clean-cadet-ftn/git-test-repo.git", GetTestPath());
+
+            GitDirectoryExists().ShouldBeTrue();
+        }
+
+        [Theory]
+        [MemberData(nameof(Data))]
+        public void Checks_presence_of_file_on_commit(string commit, bool isFilePresent)
+        {
+            ICodeRepository gitAdapter = new GitCodeRepository();
+            var fileName = GetTestPath() + _separator +  "LibGit2Sharp" + _separator + "BlameOptions.cs";
+
+            gitAdapter.CheckoutCommit(commit, GetTestPath());
+
+            File.Exists(fileName).ShouldBe(isFilePresent);
+        }
+
+        public static IEnumerable<object[]> Data()
+        {
+            return new List<object[]>
+            {
+                new object[] { "a3f95fc9e92aa4bec32f4c4a535b0316ec2ea470", false },
+                new object[] { "7fc4be5193dbdd08538b4b150332b5a73770e0f6", true }
+            };
+        }
+        
+        private bool GitDirectoryExists()
+        {
+            return Directory.Exists(GetTestPath() + _separator + ".git");
+        }
+
+        private string GetTestPath()
+        {
+            return Path.GetPathRoot(Environment.SystemDirectory) + "test-repository" + _separator + "TestRepo";
+        }
+    }
+}

--- a/DataSetExplorerTests/Unit/ImporterTests.cs
+++ b/DataSetExplorerTests/Unit/ImporterTests.cs
@@ -32,7 +32,7 @@ namespace DataSetExplorer.Tests.Unit
                 new Annotator(2, 2, 2),
                 new Annotator(3, 2, 3)
             };
-            JoinInstancesAndAnnotators(ref classes, annotators);
+            JoinInstancesAndAnnotators(classes, annotators);
 
             var allClassAnnotations = classes.SelectMany(c => c.Annotations);
             allClassAnnotations.First(a => a.Annotator.Id == 1).Annotator.ShouldBe(annotators.Find(a => a.Id == 1));
@@ -40,7 +40,7 @@ namespace DataSetExplorer.Tests.Unit
             allClassAnnotations.First(a => a.Annotator.Id == 3).Annotator.ShouldBe(annotators.Find(a => a.Id == 3));
         }
 
-        private void JoinInstancesAndAnnotators(ref List<DataSetInstance> annotatedInstances, List<Annotator> annotators)
+        private void JoinInstancesAndAnnotators(List<DataSetInstance> annotatedInstances, List<Annotator> annotators)
         {
             foreach (var annotation in annotatedInstances.SelectMany(i => i.Annotations))
             {


### PR DESCRIPTION
This PR expands the "[Dataset creation](https://github.com/Clean-CaDET/platform/wiki/Module-Dataset-Explorer#building-your-dataset)" use case to include integration with Git through LibGit2Sharp. It also extracts the logic for this use case to the new DataSetCreationService class.

The primary service this PR brings includes:

1. Cloning a repository;
2. Performing a checkout to the supplied commit;
3. Building a dataset from the files;
4. Saving the dataset to excel.

Once we establish a UI and database, we can move step 4 (ExportToExcel) to a separate method and replace it with 4. Saving dataset to database.