### PR TITLE
Export class cohesion graph into JSON

### DIFF
--- a/CodeModel.Tests/DataFactories/CodeFactory.cs
+++ b/CodeModel.Tests/DataFactories/CodeFactory.cs
@@ -4,7 +4,7 @@ namespace CodeModel.Tests.DataFactories
 {
     public class CodeFactory
     {
-        public IEnumerable<string> readClassFromFile(string path)
+        public IEnumerable<string> ReadClassFromFile(string path)
         {
             return new[] { System.IO.File.ReadAllText(path) };
         }

--- a/CodeModel.Tests/DataFactories/TestClasses/JSONExporter/BoxDecoratorViewModel.txt
+++ b/CodeModel.Tests/DataFactories/TestClasses/JSONExporter/BoxDecoratorViewModel.txt
@@ -1,0 +1,646 @@
+﻿#nullable disable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Core2D.Model;
+using Core2D.Model.Input;
+using Core2D.Model.Renderer;
+using Core2D.ViewModels.Containers;
+using Core2D.ViewModels.Layout;
+using Core2D.ViewModels.Shapes;
+using Core2D.ViewModels.Style;
+using Core2D.Spatial;
+
+namespace Core2D.ViewModels.Editor.Tools.Decorators
+{
+    public class BoxDecoratorViewModel : ViewModelBase, IDrawable, IDecorator
+    {
+        private enum Mode
+        {
+            None,
+            Move,
+            Rotate,
+            Top,
+            Bottom,
+            Left,
+            Right,
+            TopLeft,
+            TopRight,
+            BottomLeft,
+            BottomRight
+        }
+
+        private bool _isVisible;
+        [AutoNotify] private ShapeStyleViewModel _style;
+        [AutoNotify] private bool _isStroked;
+        [AutoNotify] private bool _isFilled;
+        [AutoNotify] private LayerContainerViewModel _layer;
+        [AutoNotify] private IList<BaseShapeViewModel> _shapes;
+        private readonly IFactory _factory;
+        private readonly decimal _sizeLarge;
+        private readonly decimal _sizeSmall;
+        private readonly decimal _rotateDistance;
+        private GroupBox _groupBox;
+        private readonly ShapeStyleViewModel _handleStyle;
+        private readonly ShapeStyleViewModel _boundsStyle;
+        private readonly ShapeStyleViewModel _selectedHandleStyle;
+        private readonly ShapeStyleViewModel _selectedBoundsStyle;
+        private readonly RectangleShapeViewModel _boundsHandle;
+        private readonly LineShapeViewModel _rotateLine;
+        private readonly EllipseShapeViewModel _rotateHandle;
+        private readonly EllipseShapeViewModel _topLeftHandle;
+        private readonly EllipseShapeViewModel _topRightHandle;
+        private readonly EllipseShapeViewModel _bottomLeftHandle;
+        private readonly EllipseShapeViewModel _bottomRightHandle;
+        private readonly RectangleShapeViewModel _topHandle;
+        private readonly RectangleShapeViewModel _bottomHandle;
+        private readonly RectangleShapeViewModel _leftHandle;
+        private readonly RectangleShapeViewModel _rightHandle;
+        private List<BaseShapeViewModel> _handles;
+        private BaseShapeViewModel _currentHandle;
+        private List<PointShapeViewModel> _points;
+        private Mode _mode = Mode.None;
+        private decimal _startX;
+        private decimal _startY;
+        private decimal _historyX;
+        private decimal _historyY;
+        private decimal _rotateAngle = 270m;
+        private bool _previousDrawPoints = true;
+
+        public bool IsVisible => _isVisible;
+
+        public BoxDecoratorViewModel(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+            _factory = serviceProvider.GetService<IFactory>();
+            _sizeLarge = 4m;
+            _sizeSmall = 4m;
+            _rotateDistance = -16.875m;
+            _handleStyle = _factory.CreateShapeStyle("Handle", 255, 0, 191, 255, 255, 255, 255, 255, 2.0);
+            _boundsStyle = _factory.CreateShapeStyle("Bounds", 255, 0, 191, 255, 255, 255, 255, 255, 1.0);
+            _selectedHandleStyle = _factory.CreateShapeStyle("SelectedHandle", 255, 0, 191, 255, 255, 0, 191, 255, 2.0);
+            _selectedBoundsStyle = _factory.CreateShapeStyle("SelectedBounds", 255, 0, 191, 255, 255, 255, 255, 255, 1.0);
+            _rotateHandle = _factory.CreateEllipseShape(0, 0, 0, 0, _handleStyle, true, true, name: "_rotateHandle");
+            _topLeftHandle = _factory.CreateEllipseShape(0, 0, 0, 0, _handleStyle, true, true, name: "_topLeftHandle");
+            _topRightHandle = _factory.CreateEllipseShape(0, 0, 0, 0, _handleStyle, true, true, name: "_topRightHandle");
+            _bottomLeftHandle = _factory.CreateEllipseShape(0, 0, 0, 0, _handleStyle, true, true, name: "_bottomLeftHandle");
+            _bottomRightHandle = _factory.CreateEllipseShape(0, 0, 0, 0, _handleStyle, true, true, name: "_bottomRightHandle");
+            _topHandle = _factory.CreateRectangleShape(0, 0, 0, 0, _handleStyle, true, true, name: "_topHandle");
+            _bottomHandle = _factory.CreateRectangleShape(0, 0, 0, 0, _handleStyle, true, true, name: "_bottomHandle");
+            _leftHandle = _factory.CreateRectangleShape(0, 0, 0, 0, _handleStyle, true, true, name: "_leftHandle");
+            _rightHandle = _factory.CreateRectangleShape(0, 0, 0, 0, _handleStyle, true, true, name: "_rightHandle");
+            _boundsHandle = _factory.CreateRectangleShape(0, 0, 0, 0, _boundsStyle, true, false, name: "_boundsHandle");
+            _rotateLine = _factory.CreateLineShape(0, 0, 0, 0, _boundsStyle, true, name: "_rotateLine");
+            _handles = new List<BaseShapeViewModel>
+            {
+                //_rotateHandle,
+                _topLeftHandle,
+                _topRightHandle,
+                _bottomLeftHandle,
+                _bottomRightHandle,
+                _topHandle,
+                _bottomHandle,
+                _leftHandle,
+                _rightHandle,
+                _boundsHandle,
+                //_rotateLine
+            };
+            _currentHandle = null;
+            _rotateHandle.State |= ShapeStateFlags.Size | ShapeStateFlags.Thickness;
+            _topLeftHandle.State |= ShapeStateFlags.Size | ShapeStateFlags.Thickness;
+            _topRightHandle.State |= ShapeStateFlags.Size | ShapeStateFlags.Thickness;
+            _bottomLeftHandle.State |= ShapeStateFlags.Size | ShapeStateFlags.Thickness;
+            _bottomRightHandle.State |= ShapeStateFlags.Size | ShapeStateFlags.Thickness;
+            _topHandle.State |= ShapeStateFlags.Size | ShapeStateFlags.Thickness;
+            _bottomHandle.State |= ShapeStateFlags.Size | ShapeStateFlags.Thickness;
+            _leftHandle.State |= ShapeStateFlags.Size | ShapeStateFlags.Thickness;
+            _rightHandle.State |= ShapeStateFlags.Size | ShapeStateFlags.Thickness;
+            _boundsHandle.State |= ShapeStateFlags.Thickness;
+            _rotateLine.State |= ShapeStateFlags.Thickness;
+        }
+
+        public override bool IsDirty()
+        {
+            var isDirty = base.IsDirty();
+
+            foreach (var handle in _handles)
+            {
+                isDirty |= handle.IsDirty();
+            }
+
+            return isDirty;
+        }
+
+        public override void Invalidate()
+        {
+            base.Invalidate();
+
+            foreach (var handle in _handles)
+            {
+                handle.Invalidate();
+            }
+        }
+
+        public virtual void DrawShape(object dc, IShapeRenderer renderer, ISelection selection)
+        {
+            if (_isVisible)
+            {
+                foreach (var handle in _handles)
+                {
+                    handle.DrawShape(dc, renderer, selection);
+                }
+            }
+        }
+
+        public virtual void DrawPoints(object dc, IShapeRenderer renderer, ISelection selection)
+        {
+        }
+
+        public virtual bool Invalidate(IShapeRenderer renderer)
+        {
+            return false;
+        }
+
+        public void Update(bool rebuild = true)
+        {
+            if (_layer is null || _shapes is null)
+            {
+                return;
+            }
+
+            if (rebuild)
+            {
+                _groupBox = new GroupBox(_shapes);
+            }
+            else
+            {
+                _groupBox.Update();
+            }
+
+            _boundsHandle.TopLeft.X = (double)_groupBox.Bounds.Left;
+            _boundsHandle.TopLeft.Y = (double)_groupBox.Bounds.Top;
+            _boundsHandle.BottomRight.X = (double)_groupBox.Bounds.Right;
+            _boundsHandle.BottomRight.Y = (double)_groupBox.Bounds.Bottom;
+
+            _rotateLine.Start.X = (double)_groupBox.Bounds.CenterX;
+            _rotateLine.Start.Y = (double)_groupBox.Bounds.Top;
+            _rotateLine.End.X = (double)_groupBox.Bounds.CenterX;
+            _rotateLine.End.Y = (double)(_groupBox.Bounds.Top + _rotateDistance);
+
+            _rotateHandle.TopLeft.X = (double)(_groupBox.Bounds.CenterX - _sizeLarge);
+            _rotateHandle.TopLeft.Y = (double)(_groupBox.Bounds.Top + _rotateDistance - _sizeLarge);
+            _rotateHandle.BottomRight.X = (double)(_groupBox.Bounds.CenterX + _sizeLarge);
+            _rotateHandle.BottomRight.Y = (double)(_groupBox.Bounds.Top + _rotateDistance + _sizeLarge);
+
+            _topLeftHandle.TopLeft.X = (double)(_groupBox.Bounds.Left - _sizeLarge);
+            _topLeftHandle.TopLeft.Y = (double)(_groupBox.Bounds.Top - _sizeLarge);
+            _topLeftHandle.BottomRight.X = (double)(_groupBox.Bounds.Left + _sizeLarge);
+            _topLeftHandle.BottomRight.Y = (double)(_groupBox.Bounds.Top + _sizeLarge);
+
+            _topRightHandle.TopLeft.X = (double)(_groupBox.Bounds.Right - _sizeLarge);
+            _topRightHandle.TopLeft.Y = (double)(_groupBox.Bounds.Top - _sizeLarge);
+            _topRightHandle.BottomRight.X = (double)(_groupBox.Bounds.Right + _sizeLarge);
+            _topRightHandle.BottomRight.Y = (double)(_groupBox.Bounds.Top + _sizeLarge);
+
+            _bottomLeftHandle.TopLeft.X = (double)(_groupBox.Bounds.Left - _sizeLarge);
+            _bottomLeftHandle.TopLeft.Y = (double)(_groupBox.Bounds.Bottom - _sizeLarge);
+            _bottomLeftHandle.BottomRight.X = (double)(_groupBox.Bounds.Left + _sizeLarge);
+            _bottomLeftHandle.BottomRight.Y = (double)(_groupBox.Bounds.Bottom + _sizeLarge);
+
+            _bottomRightHandle.TopLeft.X = (double)(_groupBox.Bounds.Right - _sizeLarge);
+            _bottomRightHandle.TopLeft.Y = (double)(_groupBox.Bounds.Bottom - _sizeLarge);
+            _bottomRightHandle.BottomRight.X = (double)(_groupBox.Bounds.Right + _sizeLarge);
+            _bottomRightHandle.BottomRight.Y = (double)(_groupBox.Bounds.Bottom + _sizeLarge);
+
+            _topHandle.TopLeft.X = (double)(_groupBox.Bounds.CenterX - _sizeSmall);
+            _topHandle.TopLeft.Y = (double)(_groupBox.Bounds.Top - _sizeSmall);
+            _topHandle.BottomRight.X = (double)(_groupBox.Bounds.CenterX + _sizeSmall);
+            _topHandle.BottomRight.Y = (double)(_groupBox.Bounds.Top + _sizeSmall);
+
+            _bottomHandle.TopLeft.X = (double)(_groupBox.Bounds.CenterX - _sizeSmall);
+            _bottomHandle.TopLeft.Y = (double)(_groupBox.Bounds.Bottom - _sizeSmall);
+            _bottomHandle.BottomRight.X = (double)(_groupBox.Bounds.CenterX + _sizeSmall);
+            _bottomHandle.BottomRight.Y = (double)(_groupBox.Bounds.Bottom + _sizeSmall);
+
+            _leftHandle.TopLeft.X = (double)(_groupBox.Bounds.Left - _sizeSmall);
+            _leftHandle.TopLeft.Y = (double)(_groupBox.Bounds.CenterY - _sizeSmall);
+            _leftHandle.BottomRight.X = (double)(_groupBox.Bounds.Left + _sizeSmall);
+            _leftHandle.BottomRight.Y = (double)(_groupBox.Bounds.CenterY + _sizeSmall);
+
+            _rightHandle.TopLeft.X = (double)(_groupBox.Bounds.Right - _sizeSmall);
+            _rightHandle.TopLeft.Y = (double)(_groupBox.Bounds.CenterY - _sizeSmall);
+            _rightHandle.BottomRight.X = (double)(_groupBox.Bounds.Right + _sizeSmall);
+            _rightHandle.BottomRight.Y = (double)(_groupBox.Bounds.CenterY + _sizeSmall);
+
+            if (_groupBox.Bounds.Height <= 0m || _groupBox.Bounds.Width <= 0m)
+            {
+                _leftHandle.State &= ~ShapeStateFlags.Visible;
+                _rightHandle.State &= ~ShapeStateFlags.Visible;
+                _topHandle.State &= ~ShapeStateFlags.Visible;
+                _bottomHandle.State &= ~ShapeStateFlags.Visible;
+                _topRightHandle.State &= ~ShapeStateFlags.Visible;
+                _bottomLeftHandle.State &= ~ShapeStateFlags.Visible;
+            }
+            else
+            {
+                _leftHandle.State |= ShapeStateFlags.Visible;
+                _rightHandle.State |= ShapeStateFlags.Visible;
+                _topHandle.State |= ShapeStateFlags.Visible;
+                _bottomHandle.State |= ShapeStateFlags.Visible;
+                _topRightHandle.State |= ShapeStateFlags.Visible;
+                _bottomLeftHandle.State |= ShapeStateFlags.Visible;
+            }
+
+            _layer.RaiseInvalidateLayer();
+        }
+
+        public void Show()
+        {
+            if (_layer is null || _shapes is null)
+            {
+                return;
+            }
+
+            if (_isVisible == true)
+            {
+                return;
+            }
+
+            var editor = _serviceProvider.GetService<ProjectEditorViewModel>();
+            _previousDrawPoints = editor.PageState.DrawPoints;
+            editor.PageState.DrawPoints = false;
+
+            _mode = Mode.None;
+            if (_currentHandle is { })
+            {
+                _currentHandle.Style = _currentHandle == _boundsHandle ? _boundsStyle : _handleStyle;
+                _currentHandle = null;
+                _points = null;
+                _rotateAngle = 0m;
+            }
+            _isVisible = true;
+
+            var shapesBuilder = _layer.Shapes.ToBuilder();
+            shapesBuilder.Add(_boundsHandle);
+            //shapesBuilder.Add(_rotateLine);
+            //shapesBuilder.Add(_rotateHandle);
+            shapesBuilder.Add(_topLeftHandle);
+            shapesBuilder.Add(_topRightHandle);
+            shapesBuilder.Add(_bottomLeftHandle);
+            shapesBuilder.Add(_bottomRightHandle);
+            shapesBuilder.Add(_topHandle);
+            shapesBuilder.Add(_bottomHandle);
+            shapesBuilder.Add(_leftHandle);
+            shapesBuilder.Add(_rightHandle);
+            _layer.Shapes = shapesBuilder.ToImmutable();
+
+            _layer.RaiseInvalidateLayer();
+        }
+
+        public void Hide()
+        {
+            if (_layer is null || _shapes is null)
+            {
+                return;
+            }
+
+            if (_isVisible == true)
+            {
+                var editor = _serviceProvider.GetService<ProjectEditorViewModel>();
+                editor.PageState.DrawPoints = _previousDrawPoints;
+            }
+
+            _mode = Mode.None;
+            if (_currentHandle is { })
+            {
+                _currentHandle.Style = _currentHandle == _boundsHandle ? _boundsStyle : _handleStyle;
+                _currentHandle = null;
+                _points = null;
+                _rotateAngle = 0m;
+            }
+            _isVisible = false;
+
+            var shapesBuilder = _layer.Shapes.ToBuilder();
+            shapesBuilder.Remove(_boundsHandle);
+            //shapesBuilder.Remove(_rotateLine);
+            //shapesBuilder.Remove(_rotateHandle);
+            shapesBuilder.Remove(_topLeftHandle);
+            shapesBuilder.Remove(_topRightHandle);
+            shapesBuilder.Remove(_bottomLeftHandle);
+            shapesBuilder.Remove(_bottomRightHandle);
+            shapesBuilder.Remove(_topHandle);
+            shapesBuilder.Remove(_bottomHandle);
+            shapesBuilder.Remove(_leftHandle);
+            shapesBuilder.Remove(_rightHandle);
+            _layer.Shapes = shapesBuilder.ToImmutable();
+            _layer.RaiseInvalidateLayer();
+        }
+
+        public bool HitTest(InputArgs args)
+        {
+            if (_isVisible == false)
+            {
+                return false;
+            }
+
+            var editor = _serviceProvider.GetService<ProjectEditorViewModel>();
+            (double x, double y) = args;
+            (decimal sx, decimal sy) = editor.TryToSnap(args);
+
+            _mode = Mode.None;
+            if (_currentHandle is { })
+            {
+                _currentHandle.Style = _currentHandle == _boundsHandle ? _boundsStyle : _handleStyle;
+                _currentHandle = null;
+                _points = null;
+                _rotateAngle = 0m;
+                _layer.RaiseInvalidateLayer();
+            }
+
+            double radius = editor.Project.Options.HitThreshold / editor.PageState.ZoomX;
+            var handles = _handles.Where(x => x.State.HasFlag(ShapeStateFlags.Visible));
+            var result = editor.HitTest.TryToGetShape(handles, new Point2(x, y), radius, editor.PageState.ZoomX);
+            if (result is { })
+            {
+                if (result == _boundsHandle)
+                {
+                    _mode = Mode.Move;
+                }
+                else if (result == _rotateHandle)
+                {
+                    _mode = Mode.Rotate;
+                }
+                else if (result == _topLeftHandle)
+                {
+                    _mode = Mode.TopLeft;
+                }
+                else if (result == _topRightHandle)
+                {
+                    _mode = Mode.TopRight;
+                }
+                else if (result == _bottomLeftHandle)
+                {
+                    _mode = Mode.BottomLeft;
+                }
+                else if (result == _bottomRightHandle)
+                {
+                    _mode = Mode.BottomRight;
+                }
+                else if (result == _topHandle)
+                {
+                    _mode = Mode.Top;
+                }
+                else if (result == _bottomHandle)
+                {
+                    _mode = Mode.Bottom;
+                }
+                else if (result == _leftHandle)
+                {
+                    _mode = Mode.Left;
+                }
+                else if (result == _rightHandle)
+                {
+                    _mode = Mode.Right;
+                }
+
+                if (_mode != Mode.None)
+                {
+                    _currentHandle = result;
+                    _currentHandle.Style = _currentHandle == _boundsHandle ? _selectedBoundsStyle : _selectedHandleStyle;
+                    _startX = sx;
+                    _startY = sy;
+                    _historyX = _startX;
+                    _historyY = _startY;
+                    _points = null;
+                    _rotateAngle = 0m;
+                    _layer.RaiseInvalidateLayer();
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public void Move(InputArgs args)
+        {
+            if (_layer is null || _shapes is null)
+            {
+                return;
+            }
+
+            if (_isVisible == false)
+            {
+                return;
+            }
+
+            var editor = _serviceProvider.GetService<ProjectEditorViewModel>();
+
+            bool isProportionalResize = args.Modifier.HasFlag(ModifierFlags.Shift);
+
+            (decimal sx, decimal sy) = editor.TryToSnap(args);
+            decimal dx = sx - _startX;
+            decimal dy = sy - _startY;
+            _startX = sx;
+            _startY = sy;
+
+            if (_points is null)
+            {
+                _points = _groupBox.GetMovablePoints();
+                if (_points is null)
+                {
+                    return;
+                }
+            }
+
+            switch (_mode)
+            {
+                case Mode.None:
+                    break;
+                case Mode.Move:
+                    {
+                        _groupBox.Translate(dx, dy, _points);
+                    }
+                    break;
+                case Mode.Rotate:
+                    {
+                        _groupBox.Rotate(sx, sy, _points, ref _rotateAngle);
+                    }
+                    break;
+                case Mode.Top:
+                    {
+                        if (isProportionalResize)
+                        {
+                            var width = _groupBox.Bounds.Width;
+                            var height = _groupBox.Bounds.Height;
+                            var ratioHeight = (height + dy) / height;
+
+                            dx = (width * ratioHeight) - width;
+
+                            _groupBox.ScaleLeft(dx / 2m, _points);
+                            _groupBox.ScaleRight(-dx / 2m, _points);
+
+                            _groupBox.ScaleTop(dy, _points);
+                        }
+                        else
+                        {
+                            _groupBox.ScaleTop(dy, _points);
+                        }
+                    }
+                    break;
+                case Mode.Bottom:
+                    {
+                        if (isProportionalResize)
+                        {
+                            var width = _groupBox.Bounds.Width;
+                            var height = _groupBox.Bounds.Height;
+                            var ratioHeight = (height + dy) / height;
+
+                            dx = (width * ratioHeight) - width;
+
+                            _groupBox.ScaleLeft(-dx / 2m, _points);
+                            _groupBox.ScaleRight(dx / 2m, _points);
+
+                            _groupBox.ScaleBottom(dy, _points);
+                        }
+                        else
+                        {
+                            _groupBox.ScaleBottom(dy, _points);
+                        }
+                    }
+                    break;
+                case Mode.Left:
+                    {
+                        if (isProportionalResize)
+                        {
+                            var width = _groupBox.Bounds.Width;
+                            var height = _groupBox.Bounds.Height;
+                            var ratioWidth = (width + dx) / width;
+
+                            dy = (height * ratioWidth) - height;
+
+                            _groupBox.ScaleTop(dy / 2m, _points);
+                            _groupBox.ScaleBottom(-dy / 2m, _points);
+
+                            _groupBox.ScaleLeft(dx, _points);
+                        }
+                        else
+                        {
+                            _groupBox.ScaleLeft(dx, _points);
+                        }
+                    }
+                    break;
+                case Mode.Right:
+                    {
+                        if (isProportionalResize)
+                        {
+                            var width = _groupBox.Bounds.Width;
+                            var height = _groupBox.Bounds.Height;
+                            var ratioWidth = (width + dx) / width;
+
+                            dy = (height * ratioWidth) - height;
+
+                            _groupBox.ScaleTop(-dy / 2m, _points);
+                            _groupBox.ScaleBottom(dy / 2m, _points);
+
+                            _groupBox.ScaleRight(dx, _points);
+                        }
+                        else
+                        {
+                            _groupBox.ScaleRight(dx, _points);
+                        }
+                    }
+                    break;
+                case Mode.TopLeft:
+                    {
+                        if (isProportionalResize)
+                        {
+                            var width = _groupBox.Bounds.Width;
+                            var height = _groupBox.Bounds.Height;
+
+                            var ratioWidth = (width + dx) / width;
+                            dy = (height * ratioWidth) - height;
+
+                            //var ratioHeight = (height + dy) / height;
+                            //dx = (width * ratioHeight) - width;
+
+                            _groupBox.ScaleTop(dy, _points);
+                            _groupBox.ScaleLeft(dx, _points);
+                        }
+                        else
+                        {
+                            _groupBox.ScaleTop(dy, _points);
+                            _groupBox.ScaleLeft(dx, _points);
+                        }
+                    }
+                    break;
+                case Mode.TopRight:
+                    {
+                        if (isProportionalResize)
+                        {
+                            var width = _groupBox.Bounds.Width;
+                            var height = _groupBox.Bounds.Height;
+
+                            var ratioWidth = (width - dx) / width;
+                            dy = (height * ratioWidth) - height;
+
+                            //var ratioHeight = (height - dy) / height;
+                            //dx = (width * ratioHeight) - width;
+
+                            _groupBox.ScaleTop(dy, _points);
+                            _groupBox.ScaleRight(dx, _points);
+                        }
+                        else
+                        {
+                            _groupBox.ScaleTop(dy, _points);
+                            _groupBox.ScaleRight(dx, _points);
+                        }
+                    }
+                    break;
+                case Mode.BottomLeft:
+                    {
+                        if (isProportionalResize)
+                        {
+                            var width = _groupBox.Bounds.Width;
+                            var height = _groupBox.Bounds.Height;
+
+                            var ratioWidth = (width - dx) / width;
+                            dy = (height * ratioWidth) - height;
+
+                            //var ratioHeight = (height - dy) / height;
+                            //dx = (width * ratioHeight) - width;
+
+                            _groupBox.ScaleBottom(dy, _points);
+                            _groupBox.ScaleLeft(dx, _points);
+                        }
+                        else
+                        {
+                            _groupBox.ScaleBottom(dy, _points);
+                            _groupBox.ScaleLeft(dx, _points);
+                        }
+                    }
+                    break;
+                case Mode.BottomRight:
+                    {
+                        if (isProportionalResize)
+                        {
+                            var width = _groupBox.Bounds.Width;
+                            var height = _groupBox.Bounds.Height;
+
+                            var ratioWidth = (width + dx) / width;
+                            dy = (height * ratioWidth) - height;
+
+                            //var ratioHeight = (height + dy) / height;
+                            //dx = (width * ratioHeight) - width;
+
+                            _groupBox.ScaleBottom(dy, _points);
+                            _groupBox.ScaleRight(dx, _points);
+                        }
+                        else
+                        {
+                            _groupBox.ScaleBottom(dy, _points);
+                            _groupBox.ScaleRight(dx, _points);
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/CodeModel.Tests/DataFactories/TestClasses/JSONExporter/IntegrationHelpers.txt
+++ b/CodeModel.Tests/DataFactories/TestClasses/JSONExporter/IntegrationHelpers.txt
@@ -1,0 +1,468 @@
+﻿#region License Information (GPL v3)
+
+/*
+    ShareX - A program that allows you to take screenshots and share any file type
+    Copyright (c) 2007-2020 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using Newtonsoft.Json;
+using ShareX.HelpersLib;
+using ShareX.Properties;
+using System;
+using System.IO;
+using System.Text;
+using System.Windows.Forms;
+
+namespace ShareX
+{
+    public static class IntegrationHelpers
+    {
+        private static readonly string ApplicationPath = $"\"{Application.ExecutablePath}\"";
+
+        private static readonly string ShellExtMenuName = "ShareX";
+        private static readonly string ShellExtMenuFiles = $@"Software\Classes\*\shell\{ShellExtMenuName}";
+        private static readonly string ShellExtMenuFilesCmd = $@"{ShellExtMenuFiles}\command";
+        private static readonly string ShellExtMenuDirectory = $@"Software\Classes\Directory\shell\{ShellExtMenuName}";
+        private static readonly string ShellExtMenuDirectoryCmd = $@"{ShellExtMenuDirectory}\command";
+        private static readonly string ShellExtDesc = Resources.IntegrationHelpers_UploadWithShareX;
+        private static readonly string ShellExtIcon = $"{ApplicationPath},0";
+        private static readonly string ShellExtPath = $"{ApplicationPath} \"%1\"";
+
+        private static readonly string ShellExtEditName = "ShareXImageEditor";
+        private static readonly string ShellExtEditImage = $@"Software\Classes\SystemFileAssociations\image\shell\{ShellExtEditName}";
+        private static readonly string ShellExtEditImageCmd = $@"{ShellExtEditImage}\command";
+        private static readonly string ShellExtEditDesc = Resources.IntegrationHelpers_EditWithShareX;
+        private static readonly string ShellExtEditIcon = $"{ApplicationPath},0";
+        private static readonly string ShellExtEditPath = $"{ApplicationPath} -ImageEditor \"%1\"";
+
+        private static readonly string ShellCustomUploaderExtensionPath = @"Software\Classes\.sxcu";
+        private static readonly string ShellCustomUploaderExtensionValue = "ShareX.sxcu";
+        private static readonly string ShellCustomUploaderAssociatePath = $@"Software\Classes\{ShellCustomUploaderExtensionValue}";
+        private static readonly string ShellCustomUploaderAssociateValue = "ShareX custom uploader";
+        private static readonly string ShellCustomUploaderIconPath = $@"{ShellCustomUploaderAssociatePath}\DefaultIcon";
+        private static readonly string ShellCustomUploaderIconValue = $"{ApplicationPath},0";
+        private static readonly string ShellCustomUploaderCommandPath = $@"{ShellCustomUploaderAssociatePath}\shell\open\command";
+        private static readonly string ShellCustomUploaderCommandValue = $"{ApplicationPath} -CustomUploader \"%1\"";
+
+        private static readonly string ShellImageEffectExtensionPath = @"Software\Classes\.sxie";
+        private static readonly string ShellImageEffectExtensionValue = "ShareX.sxie";
+        private static readonly string ShellImageEffectAssociatePath = $@"Software\Classes\{ShellImageEffectExtensionValue}";
+        private static readonly string ShellImageEffectAssociateValue = "ShareX image effect";
+        private static readonly string ShellImageEffectIconPath = $@"{ShellImageEffectAssociatePath}\DefaultIcon";
+        private static readonly string ShellImageEffectIconValue = $"{ApplicationPath},0";
+        private static readonly string ShellImageEffectCommandPath = $@"{ShellImageEffectAssociatePath}\shell\open\command";
+        private static readonly string ShellImageEffectCommandValue = $"{ApplicationPath} -ImageEffect \"%1\"";
+
+        private static readonly string ChromeNativeMessagingHosts = @"SOFTWARE\Google\Chrome\NativeMessagingHosts\com.getsharex.sharex";
+        private static readonly string FirefoxNativeMessagingHosts = @"SOFTWARE\Mozilla\NativeMessagingHosts\ShareX";
+
+        public static bool CheckShellContextMenuButton()
+        {
+            try
+            {
+                return RegistryHelpers.CheckRegistry(ShellExtMenuFilesCmd, null, ShellExtPath) &&
+                    RegistryHelpers.CheckRegistry(ShellExtMenuDirectoryCmd, null, ShellExtPath);
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+            }
+
+            return false;
+        }
+
+        public static void CreateShellContextMenuButton(bool create)
+        {
+            try
+            {
+                if (create)
+                {
+                    UnregisterShellContextMenuButton();
+                    RegisterShellContextMenuButton();
+                }
+                else
+                {
+                    UnregisterShellContextMenuButton();
+                }
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+            }
+        }
+
+        private static void RegisterShellContextMenuButton()
+        {
+            RegistryHelpers.CreateRegistry(ShellExtMenuFiles, ShellExtDesc);
+            RegistryHelpers.CreateRegistry(ShellExtMenuFiles, "Icon", ShellExtIcon);
+            RegistryHelpers.CreateRegistry(ShellExtMenuFilesCmd, ShellExtPath);
+
+            RegistryHelpers.CreateRegistry(ShellExtMenuDirectory, ShellExtDesc);
+            RegistryHelpers.CreateRegistry(ShellExtMenuDirectory, "Icon", ShellExtIcon);
+            RegistryHelpers.CreateRegistry(ShellExtMenuDirectoryCmd, ShellExtPath);
+        }
+
+        private static void UnregisterShellContextMenuButton()
+        {
+            RegistryHelpers.RemoveRegistry(ShellExtMenuFiles, true);
+            RegistryHelpers.RemoveRegistry(ShellExtMenuDirectory, true);
+        }
+
+        public static bool CheckEditShellContextMenuButton()
+        {
+            try
+            {
+                return RegistryHelpers.CheckRegistry(ShellExtEditImageCmd, null, ShellExtEditPath);
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+            }
+
+            return false;
+        }
+
+        public static void CreateEditShellContextMenuButton(bool create)
+        {
+            try
+            {
+                if (create)
+                {
+                    UnregisterEditShellContextMenuButton();
+                    RegisterEditShellContextMenuButton();
+                }
+                else
+                {
+                    UnregisterEditShellContextMenuButton();
+                }
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+            }
+        }
+
+        private static void RegisterEditShellContextMenuButton()
+        {
+            RegistryHelpers.CreateRegistry(ShellExtEditImage, ShellExtEditDesc);
+            RegistryHelpers.CreateRegistry(ShellExtEditImage, "Icon", ShellExtEditIcon);
+            RegistryHelpers.CreateRegistry(ShellExtEditImageCmd, ShellExtEditPath);
+        }
+
+        private static void UnregisterEditShellContextMenuButton()
+        {
+            RegistryHelpers.RemoveRegistry(ShellExtEditImage, true);
+        }
+
+        public static bool CheckCustomUploaderExtension()
+        {
+            try
+            {
+                return RegistryHelpers.CheckRegistry(ShellCustomUploaderExtensionPath, null, ShellCustomUploaderExtensionValue) &&
+                    RegistryHelpers.CheckRegistry(ShellCustomUploaderCommandPath, null, ShellCustomUploaderCommandValue);
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+            }
+
+            return false;
+        }
+
+        public static void CreateCustomUploaderExtension(bool create)
+        {
+            try
+            {
+                if (create)
+                {
+                    UnregisterCustomUploaderExtension();
+                    RegisterCustomUploaderExtension();
+                }
+                else
+                {
+                    UnregisterCustomUploaderExtension();
+                }
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+            }
+        }
+
+        private static void RegisterCustomUploaderExtension()
+        {
+            RegistryHelpers.CreateRegistry(ShellCustomUploaderExtensionPath, ShellCustomUploaderExtensionValue);
+            RegistryHelpers.CreateRegistry(ShellCustomUploaderAssociatePath, ShellCustomUploaderAssociateValue);
+            RegistryHelpers.CreateRegistry(ShellCustomUploaderIconPath, ShellCustomUploaderIconValue);
+            RegistryHelpers.CreateRegistry(ShellCustomUploaderCommandPath, ShellCustomUploaderCommandValue);
+
+            NativeMethods.SHChangeNotify(HChangeNotifyEventID.SHCNE_ASSOCCHANGED, HChangeNotifyFlags.SHCNF_FLUSH, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        private static void UnregisterCustomUploaderExtension()
+        {
+            RegistryHelpers.RemoveRegistry(ShellCustomUploaderExtensionPath);
+            RegistryHelpers.RemoveRegistry(ShellCustomUploaderAssociatePath, true);
+        }
+
+        public static bool CheckImageEffectExtension()
+        {
+            try
+            {
+                return RegistryHelpers.CheckRegistry(ShellImageEffectExtensionPath, null, ShellImageEffectExtensionValue) &&
+                    RegistryHelpers.CheckRegistry(ShellImageEffectCommandPath, null, ShellImageEffectCommandValue);
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+            }
+
+            return false;
+        }
+
+        public static void CreateImageEffectExtension(bool create)
+        {
+            try
+            {
+                if (create)
+                {
+                    UnregisterImageEffectExtension();
+                    RegisterImageEffectExtension();
+                }
+                else
+                {
+                    UnregisterImageEffectExtension();
+                }
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+            }
+        }
+
+        private static void RegisterImageEffectExtension()
+        {
+            RegistryHelpers.CreateRegistry(ShellImageEffectExtensionPath, ShellImageEffectExtensionValue);
+            RegistryHelpers.CreateRegistry(ShellImageEffectAssociatePath, ShellImageEffectAssociateValue);
+            RegistryHelpers.CreateRegistry(ShellImageEffectIconPath, ShellImageEffectIconValue);
+            RegistryHelpers.CreateRegistry(ShellImageEffectCommandPath, ShellImageEffectCommandValue);
+
+            NativeMethods.SHChangeNotify(HChangeNotifyEventID.SHCNE_ASSOCCHANGED, HChangeNotifyFlags.SHCNF_FLUSH, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        private static void UnregisterImageEffectExtension()
+        {
+            RegistryHelpers.RemoveRegistry(ShellImageEffectExtensionPath);
+            RegistryHelpers.RemoveRegistry(ShellImageEffectAssociatePath, true);
+        }
+
+        public static bool CheckChromeExtensionSupport()
+        {
+            try
+            {
+                return RegistryHelpers.CheckRegistry(ChromeNativeMessagingHosts, null, Program.ChromeHostManifestFilePath) &&
+                    File.Exists(Program.ChromeHostManifestFilePath);
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+            }
+
+            return false;
+        }
+
+        public static void CreateChromeExtensionSupport(bool create)
+        {
+            try
+            {
+                if (create)
+                {
+                    UnregisterChromeExtensionSupport();
+                    RegisterChromeExtensionSupport();
+                }
+                else
+                {
+                    UnregisterChromeExtensionSupport();
+                }
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+            }
+        }
+
+        private static void CreateChromeHostManifest(string filepath)
+        {
+            Helpers.CreateDirectoryFromFilePath(filepath);
+
+            ChromeManifest manifest = new ChromeManifest()
+            {
+                name = "com.getsharex.sharex",
+                description = "ShareX",
+                path = Program.NativeMessagingHostFilePath,
+                type = "stdio",
+                allowed_origins = new string[] { "chrome-extension://nlkoigbdolhchiicbonbihbphgamnaoc/" }
+            };
+
+            string json = JsonConvert.SerializeObject(manifest, Formatting.Indented);
+
+            File.WriteAllText(filepath, json, Encoding.UTF8);
+        }
+
+        private static void RegisterChromeExtensionSupport()
+        {
+            CreateChromeHostManifest(Program.ChromeHostManifestFilePath);
+
+            RegistryHelpers.CreateRegistry(ChromeNativeMessagingHosts, Program.ChromeHostManifestFilePath);
+        }
+
+        private static void UnregisterChromeExtensionSupport()
+        {
+            if (File.Exists(Program.ChromeHostManifestFilePath))
+            {
+                File.Delete(Program.ChromeHostManifestFilePath);
+            }
+
+            RegistryHelpers.RemoveRegistry(ChromeNativeMessagingHosts);
+        }
+
+        public static bool CheckFirefoxAddonSupport()
+        {
+            try
+            {
+                return RegistryHelpers.CheckRegistry(FirefoxNativeMessagingHosts, null, Program.FirefoxHostManifestFilePath) &&
+                    File.Exists(Program.FirefoxHostManifestFilePath);
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+            }
+
+            return false;
+        }
+
+        public static void CreateFirefoxAddonSupport(bool create)
+        {
+            try
+            {
+                if (create)
+                {
+                    UnregisterFirefoxAddonSupport();
+                    RegisterFirefoxAddonSupport();
+                }
+                else
+                {
+                    UnregisterFirefoxAddonSupport();
+                }
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+            }
+        }
+
+        private static void CreateFirefoxHostManifest(string filepath)
+        {
+            Helpers.CreateDirectoryFromFilePath(filepath);
+
+            FirefoxManifest manifest = new FirefoxManifest()
+            {
+                name = "ShareX",
+                description = "ShareX",
+                path = Program.NativeMessagingHostFilePath,
+                type = "stdio",
+                allowed_extensions = new string[] { "firefox@getsharex.com" }
+            };
+
+            string json = JsonConvert.SerializeObject(manifest, Formatting.Indented);
+
+            File.WriteAllText(filepath, json, Encoding.UTF8);
+        }
+
+        private static void RegisterFirefoxAddonSupport()
+        {
+            CreateFirefoxHostManifest(Program.FirefoxHostManifestFilePath);
+
+            RegistryHelpers.CreateRegistry(FirefoxNativeMessagingHosts, Program.FirefoxHostManifestFilePath);
+        }
+
+        private static void UnregisterFirefoxAddonSupport()
+        {
+            if (File.Exists(Program.FirefoxHostManifestFilePath))
+            {
+                File.Delete(Program.FirefoxHostManifestFilePath);
+            }
+
+            RegistryHelpers.RemoveRegistry(FirefoxNativeMessagingHosts);
+        }
+
+        public static bool CheckSendToMenuButton()
+        {
+            return ShortcutHelpers.CheckShortcut(Environment.SpecialFolder.SendTo, Application.ExecutablePath);
+        }
+
+        public static bool CreateSendToMenuButton(bool create)
+        {
+            return ShortcutHelpers.SetShortcut(create, Environment.SpecialFolder.SendTo, Application.ExecutablePath);
+        }
+
+        public static bool CheckSteamShowInApp()
+        {
+            return File.Exists(Program.SteamInAppFilePath);
+        }
+
+        public static void SteamShowInApp(bool showInApp)
+        {
+            string path = Program.SteamInAppFilePath;
+
+            try
+            {
+                if (showInApp)
+                {
+                    Helpers.CreateEmptyFile(path);
+                }
+                else if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+                e.ShowError();
+                return;
+            }
+
+            MessageBox.Show(Resources.ApplicationSettingsForm_cbSteamShowInApp_CheckedChanged_For_settings_to_take_effect_ShareX_needs_to_be_reopened_from_Steam_,
+                "ShareX", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        public static void Uninstall()
+        {
+            StartupManagerSingletonProvider.CurrentStartupManager.State = StartupState.Disabled;
+            CreateShellContextMenuButton(false);
+            CreateEditShellContextMenuButton(false);
+            CreateCustomUploaderExtension(false);
+            CreateImageEffectExtension(false);
+            CreateSendToMenuButton(false);
+        }
+    }
+}

--- a/CodeModel.Tests/DataFactories/TestClasses/JSONExporter/RegionCaptureForm.txt
+++ b/CodeModel.Tests/DataFactories/TestClasses/JSONExporter/RegionCaptureForm.txt
@@ -1,0 +1,1536 @@
+﻿#region License Information (GPL v3)
+
+/*
+    ShareX - A program that allows you to take screenshots and share any file type
+    Copyright (c) 2007-2020 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using ShareX.HelpersLib;
+using ShareX.ScreenCaptureLib.Properties;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace ShareX.ScreenCaptureLib
+{
+    public sealed class RegionCaptureForm : Form
+    {
+        public static GraphicsPath LastRegionFillPath { get; private set; }
+
+        public event Func<Bitmap, string, string> SaveImageRequested;
+        public event Func<Bitmap, string, string> SaveImageAsRequested;
+        public event Action<Bitmap> CopyImageRequested;
+        public event Action<Bitmap> UploadImageRequested;
+        public event Action<Bitmap> PrintImageRequested;
+
+        public RegionCaptureOptions Options { get; set; }
+        public Rectangle ClientArea { get; private set; }
+        public Bitmap Canvas { get; private set; }
+        public Rectangle CanvasRectangle { get; internal set; }
+        public RegionResult Result { get; private set; }
+        public int FPS { get; private set; }
+        public int MonitorIndex { get; set; }
+        public string ImageFilePath { get; set; }
+        public bool IsFullscreen { get; private set; }
+
+        public RegionCaptureMode Mode { get; private set; }
+        public bool IsEditorMode => Mode == RegionCaptureMode.Editor || Mode == RegionCaptureMode.TaskEditor;
+        public bool IsAnnotationMode => Mode == RegionCaptureMode.Annotation || IsEditorMode;
+        public bool IsModified => ShapeManager != null && ShapeManager.IsModified;
+
+        public Point CurrentPosition { get; private set; }
+        public Point PanningStrech = new Point();
+
+        public SimpleWindowInfo SelectedWindow { get; private set; }
+
+        public Vector2 CanvasCenterOffset { get; set; } = new Vector2(0f, 0f);
+
+        internal ShapeManager ShapeManager { get; private set; }
+        internal bool IsClosing { get; private set; }
+
+        internal Bitmap DimmedCanvas;
+        internal Image CustomNodeImage = Resources.CircleNode;
+        internal int ToolbarHeight;
+
+        private InputManager InputManager => ShapeManager.InputManager;
+        private TextureBrush backgroundBrush, backgroundHighlightBrush;
+        private GraphicsPath regionFillPath, regionDrawPath;
+        private Pen borderPen, borderDotPen, borderDotStaticPen, textOuterBorderPen, textInnerBorderPen, markerPen, canvasBorderPen;
+        private Brush textBrush, textShadowBrush, textBackgroundBrush;
+        private Font infoFont, infoFontMedium, infoFontBig;
+        private Stopwatch timerStart, timerFPS;
+        private int frameCount;
+        private bool pause, isKeyAllowed, forceClose;
+        private RectangleAnimation regionAnimation;
+        private TextAnimation editorPanTipAnimation;
+        private Cursor defaultCursor, openHandCursor, closedHandCursor;
+        private Color canvasBackgroundColor, canvasBorderColor, textColor, textShadowColor, textBackgroundColor, textOuterBorderColor, textInnerBorderColor;
+
+        public RegionCaptureForm(RegionCaptureMode mode, RegionCaptureOptions options, Bitmap canvas = null)
+        {
+            Mode = mode;
+            Options = options;
+
+            if (canvas == null)
+            {
+                canvas = new Screenshot().CaptureFullscreen();
+            }
+
+            IsFullscreen = !IsEditorMode || Options.ImageEditorStartMode == ImageEditorStartMode.Fullscreen;
+
+            ClientArea = CaptureHelpers.GetScreenBounds0Based();
+            CanvasRectangle = ClientArea;
+
+            timerStart = new Stopwatch();
+            timerFPS = new Stopwatch();
+            regionAnimation = new RectangleAnimation()
+            {
+                Duration = TimeSpan.FromMilliseconds(200)
+            };
+
+            if (IsEditorMode && Options.ShowEditorPanTip)
+            {
+                editorPanTipAnimation = new TextAnimation()
+                {
+                    Duration = TimeSpan.FromMilliseconds(5000),
+                    FadeOutDuration = TimeSpan.FromMilliseconds(1000),
+                    Text = Resources.RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging
+                };
+            }
+
+            borderPen = new Pen(Color.Black);
+            borderDotPen = new Pen(Color.White) { DashPattern = new float[] { 5, 5 } };
+            borderDotStaticPen = new Pen(Color.White) { DashPattern = new float[] { 5, 5 } };
+            infoFont = new Font("Verdana", 9);
+            infoFontMedium = new Font("Verdana", 12);
+            infoFontBig = new Font("Verdana", 16, FontStyle.Bold);
+            markerPen = new Pen(Color.FromArgb(200, Color.Red));
+
+            if (ShareXResources.UseCustomTheme)
+            {
+                canvasBackgroundColor = ShareXResources.Theme.BackgroundColor;
+                canvasBorderColor = ShareXResources.Theme.BorderColor;
+                textColor = ShareXResources.Theme.TextColor;
+                textShadowColor = ShareXResources.Theme.BorderColor;
+                textBackgroundColor = Color.FromArgb(200, ShareXResources.Theme.BackgroundColor);
+                textOuterBorderColor = Color.FromArgb(200, ShareXResources.Theme.SeparatorDarkColor);
+                textInnerBorderColor = Color.FromArgb(200, ShareXResources.Theme.SeparatorLightColor);
+            }
+            else
+            {
+                canvasBackgroundColor = Color.FromArgb(200, 200, 200);
+                canvasBorderColor = Color.FromArgb(176, 176, 176);
+                textColor = Color.White;
+                textShadowColor = Color.Black;
+                textBackgroundColor = Color.FromArgb(200, Color.FromArgb(42, 131, 199));
+                textOuterBorderColor = Color.FromArgb(200, Color.White);
+                textInnerBorderColor = Color.FromArgb(200, Color.FromArgb(0, 81, 145));
+            }
+
+            canvasBorderPen = new Pen(canvasBorderColor);
+            textBrush = new SolidBrush(textColor);
+            textShadowBrush = new SolidBrush(textShadowColor);
+            textBackgroundBrush = new SolidBrush(textBackgroundColor);
+            textOuterBorderPen = new Pen(textOuterBorderColor);
+            textInnerBorderPen = new Pen(textInnerBorderColor);
+
+            Prepare(canvas);
+
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            SuspendLayout();
+
+            AutoScaleMode = AutoScaleMode.None;
+            defaultCursor = Helpers.CreateCursor(Resources.Crosshair);
+            openHandCursor = Helpers.CreateCursor(Resources.openhand);
+            closedHandCursor = Helpers.CreateCursor(Resources.closedhand);
+            SetDefaultCursor();
+            Icon = ShareXResources.Icon;
+            SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.UserPaint | ControlStyles.AllPaintingInWmPaint, true);
+            UpdateTitle();
+            StartPosition = FormStartPosition.Manual;
+
+            if (IsFullscreen)
+            {
+                FormBorderStyle = FormBorderStyle.None;
+                Bounds = CaptureHelpers.GetScreenBounds();
+                ShowInTaskbar = false;
+#if !DEBUG
+                TopMost = true;
+#endif
+            }
+            else
+            {
+                FormBorderStyle = FormBorderStyle.Sizable;
+                MinimumSize = new Size(800, 550);
+
+                if (Options.ImageEditorStartMode == ImageEditorStartMode.PreviousState)
+                {
+                    Options.ImageEditorWindowState.ApplyFormState(this);
+                }
+                else
+                {
+                    Rectangle activeScreenWorkingArea = CaptureHelpers.GetActiveScreenWorkingArea();
+                    Size size = new Size(900, 700);
+                    bool isMaximized = Options.ImageEditorStartMode == ImageEditorStartMode.Maximized;
+
+                    if (Options.ImageEditorStartMode == ImageEditorStartMode.AutoSize)
+                    {
+                        int margin = 100;
+                        Size canvasWindowSize = new Size(Canvas.Width + (SystemInformation.BorderSize.Width * 2) + margin,
+                            Canvas.Height + SystemInformation.CaptionHeight + (SystemInformation.BorderSize.Height * 2) + margin);
+                        canvasWindowSize = new Size(Math.Max(MinimumSize.Width, canvasWindowSize.Width), Math.Max(MinimumSize.Height, canvasWindowSize.Height));
+
+                        if (canvasWindowSize.Width < activeScreenWorkingArea.Width && canvasWindowSize.Height < activeScreenWorkingArea.Height)
+                        {
+                            size = canvasWindowSize;
+                        }
+                        else
+                        {
+                            isMaximized = true;
+                        }
+                    }
+
+                    Bounds = new Rectangle(activeScreenWorkingArea.X + (activeScreenWorkingArea.Width / 2) - (size.Width / 2),
+                        activeScreenWorkingArea.Y + (activeScreenWorkingArea.Height / 2) - (size.Height / 2), size.Width, size.Height);
+
+                    if (isMaximized)
+                    {
+                        WindowState = FormWindowState.Maximized;
+                    }
+                    else
+                    {
+                        WindowState = FormWindowState.Normal;
+                    }
+                }
+
+                ShowInTaskbar = true;
+            }
+
+            Shown += RegionCaptureForm_Shown;
+            KeyDown += RegionCaptureForm_KeyDown;
+            MouseDown += RegionCaptureForm_MouseDown;
+            Resize += RegionCaptureForm_Resize;
+            LocationChanged += RegionCaptureForm_LocationChanged;
+            LostFocus += RegionCaptureForm_LostFocus;
+            GotFocus += RegionCaptureForm_GotFocus;
+            FormClosing += RegionCaptureForm_FormClosing;
+
+            ResumeLayout(false);
+        }
+
+        internal void UpdateTitle()
+        {
+            if (forceClose) return;
+
+            string text;
+
+            if (IsEditorMode)
+            {
+                text = "ShareX - " + Resources.RegionCaptureForm_InitializeComponent_ImageEditor;
+
+                if (Canvas != null)
+                {
+                    text += $" - {Canvas.Width}x{Canvas.Height}";
+                }
+
+                string filename = Helpers.GetFilenameSafe(ImageFilePath);
+
+                if (!string.IsNullOrEmpty(filename))
+                {
+                    text += " - " + filename;
+                }
+
+                if (!IsFullscreen && Options.ShowFPS)
+                {
+                    text += " - FPS: " + FPS.ToString();
+                }
+            }
+            else
+            {
+                text = "ShareX - " + Resources.BaseRegionForm_InitializeComponent_Region_capture;
+            }
+
+            Text = text;
+        }
+
+        private void Prepare(Bitmap canvas = null)
+        {
+            ShapeManager = new ShapeManager(this);
+            ShapeManager.WindowCaptureMode = !IsEditorMode && Options.DetectWindows;
+            ShapeManager.IncludeControls = Options.DetectControls;
+
+            InitBackground(canvas);
+
+            if (Mode == RegionCaptureMode.OneClick || ShapeManager.WindowCaptureMode)
+            {
+                IntPtr handle = Handle;
+
+                Task.Run(() =>
+                {
+                    WindowsRectangleList wla = new WindowsRectangleList();
+                    wla.IgnoreHandle = handle;
+                    wla.IncludeChildWindows = ShapeManager.IncludeControls;
+                    ShapeManager.Windows = wla.GetWindowInfoListAsync(5000);
+                });
+            }
+        }
+
+        internal void InitBackground(Bitmap canvas, bool centerCanvas = true)
+        {
+            if (Canvas != null) Canvas.Dispose();
+            if (backgroundBrush != null) backgroundBrush.Dispose();
+            if (backgroundHighlightBrush != null) backgroundHighlightBrush.Dispose();
+
+            Canvas = canvas;
+
+            if (IsEditorMode)
+            {
+                UpdateTitle();
+
+                CanvasRectangle = new Rectangle(CanvasRectangle.X, CanvasRectangle.Y, Canvas.Width, Canvas.Height);
+
+                using (Bitmap background = new Bitmap(Canvas.Width, Canvas.Height))
+                using (Graphics g = Graphics.FromImage(background))
+                {
+                    Rectangle sourceRect = new Rectangle(0, 0, Canvas.Width, Canvas.Height);
+
+                    if (ShareXResources.Theme.CheckerSize > 0)
+                    {
+                        using (Bitmap checkers = ImageHelpers.DrawCheckers(Canvas.Width, Canvas.Height, ShareXResources.Theme.CheckerSize,
+                            ShareXResources.Theme.CheckerColor, ShareXResources.Theme.CheckerColor2))
+                        {
+                            g.DrawImage(checkers, sourceRect);
+                        }
+                    }
+                    else
+                    {
+                        using (Brush canvasBrush = new SolidBrush(ShareXResources.Theme.CheckerColor))
+                        {
+                            g.FillRectangle(canvasBrush, sourceRect);
+                        }
+                    }
+
+                    g.DrawImage(Canvas, sourceRect);
+
+                    backgroundBrush = new TextureBrush(background) { WrapMode = WrapMode.Clamp };
+                    backgroundBrush.TranslateTransform(CanvasRectangle.X, CanvasRectangle.Y);
+                }
+
+                if (centerCanvas)
+                {
+                    CenterCanvas();
+                }
+            }
+            else if (Options.UseDimming)
+            {
+                DimmedCanvas?.Dispose();
+                DimmedCanvas = (Bitmap)Canvas.Clone();
+
+                using (Graphics g = Graphics.FromImage(DimmedCanvas))
+                using (Brush brush = new SolidBrush(Color.FromArgb(30, Color.Black)))
+                {
+                    g.FillRectangle(brush, 0, 0, DimmedCanvas.Width, DimmedCanvas.Height);
+
+                    backgroundBrush = new TextureBrush(DimmedCanvas) { WrapMode = WrapMode.Clamp };
+                }
+
+                backgroundHighlightBrush = new TextureBrush(Canvas) { WrapMode = WrapMode.Clamp };
+            }
+            else
+            {
+                backgroundBrush = new TextureBrush(Canvas) { WrapMode = WrapMode.Clamp };
+            }
+        }
+
+        private void OnMoved()
+        {
+            if (ShapeManager != null)
+            {
+                UpdateCoordinates();
+
+                if (IsAnnotationMode && ShapeManager.ToolbarCreated)
+                {
+                    ShapeManager.UpdateMenuMaxWidth(ClientSize.Width);
+                    ShapeManager.UpdateMenuPosition();
+                }
+            }
+        }
+
+        private void Pan(int deltaX, int deltaY, bool usePanningStretch = true)
+        {
+            if (usePanningStretch)
+            {
+                PanningStrech.X -= deltaX;
+                PanningStrech.Y -= deltaY;
+            }
+
+            Size panLimitSize = new Size(
+                Math.Min((int)Math.Round(ClientArea.Width * 0.25f), CanvasRectangle.Width),
+                Math.Min((int)Math.Round(ClientArea.Height * 0.25f), CanvasRectangle.Height));
+
+            Rectangle limitRectangle = new Rectangle(
+                ClientArea.X + panLimitSize.Width, ClientArea.Y + panLimitSize.Height,
+                ClientArea.Width - (panLimitSize.Width * 2), ClientArea.Height - (panLimitSize.Height * 2));
+
+            deltaX = Math.Max(deltaX, limitRectangle.Left - CanvasRectangle.Right);
+            deltaX = Math.Min(deltaX, limitRectangle.Right - CanvasRectangle.Left);
+            deltaY = Math.Max(deltaY, limitRectangle.Top - CanvasRectangle.Bottom);
+            deltaY = Math.Min(deltaY, limitRectangle.Bottom - CanvasRectangle.Top);
+
+            if (usePanningStretch)
+            {
+                deltaX -= Math.Min(Math.Max(deltaX, 0), Math.Max(0, PanningStrech.X));
+                deltaX -= Math.Max(Math.Min(deltaX, 0), Math.Min(0, PanningStrech.X));
+                deltaY -= Math.Min(Math.Max(deltaY, 0), Math.Max(0, PanningStrech.Y));
+                deltaY -= Math.Max(Math.Min(deltaY, 0), Math.Min(0, PanningStrech.Y));
+
+                PanningStrech.X += deltaX;
+                PanningStrech.Y += deltaY;
+            }
+
+            CanvasRectangle = CanvasRectangle.LocationOffset(deltaX, deltaY);
+
+            if (backgroundBrush != null)
+            {
+                backgroundBrush.TranslateTransform(deltaX, deltaY);
+            }
+
+            if (ShapeManager != null)
+            {
+                ShapeManager.MoveAll(deltaX, deltaY);
+            }
+        }
+
+        private void Pan(Point delta)
+        {
+            Pan(delta.X, delta.Y);
+        }
+
+        private void AutomaticPan(Vector2 centerOffset)
+        {
+            if (IsEditorMode)
+            {
+                int x = (int)Math.Round((ClientArea.Width * 0.5f) + centerOffset.X);
+                int y = (int)Math.Round((ClientArea.Height * 0.5f) + centerOffset.Y);
+                int newX = x - (CanvasRectangle.Width / 2);
+                int newY = y - (CanvasRectangle.Height / 2);
+                int deltaX = newX - CanvasRectangle.X;
+                int deltaY = newY - CanvasRectangle.Y;
+                Pan(deltaX, deltaY, false);
+            }
+        }
+
+        public void AutomaticPan()
+        {
+            AutomaticPan(CanvasCenterOffset);
+        }
+
+        private void UpdateCenterOffset()
+        {
+            CanvasCenterOffset = new Vector2(
+                (CanvasRectangle.X + (CanvasRectangle.Width / 2f)) - (ClientArea.Width / 2f),
+                (CanvasRectangle.Y + (CanvasRectangle.Height / 2f)) - (ClientArea.Height / 2f));
+        }
+
+        public void CenterCanvas()
+        {
+            CanvasCenterOffset = new Vector2(0f, ToolbarHeight / 2f);
+            AutomaticPan();
+        }
+
+        public void SetDefaultCursor()
+        {
+            if (Cursor != defaultCursor)
+            {
+                Cursor = defaultCursor;
+            }
+        }
+
+        public void SetHandCursor(bool grabbing)
+        {
+            if (grabbing)
+            {
+                if (Cursor != closedHandCursor)
+                {
+                    Cursor = closedHandCursor;
+                }
+            }
+            else
+            {
+                if (Cursor != openHandCursor)
+                {
+                    Cursor = openHandCursor;
+                }
+            }
+        }
+
+        private void RegionCaptureForm_Shown(object sender, EventArgs e)
+        {
+            this.ForceActivate();
+
+            OnMoved();
+            CenterCanvas();
+
+            if (IsEditorMode && Options.ShowEditorPanTip && editorPanTipAnimation != null)
+            {
+                editorPanTipAnimation.Start();
+            }
+        }
+
+        private void RegionCaptureForm_Resize(object sender, EventArgs e)
+        {
+            OnMoved();
+            AutomaticPan();
+        }
+
+        private void RegionCaptureForm_LocationChanged(object sender, EventArgs e)
+        {
+            OnMoved();
+        }
+
+        private void RegionCaptureForm_GotFocus(object sender, EventArgs e)
+        {
+            Resume();
+        }
+
+        private void RegionCaptureForm_LostFocus(object sender, EventArgs e)
+        {
+            Pause();
+        }
+
+        private void RegionCaptureForm_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (IsEditorMode)
+            {
+                if (e.CloseReason == CloseReason.UserClosing && !forceClose && !IsFullscreen && !ShowExitConfirmation())
+                {
+                    e.Cancel = true;
+                    return;
+                }
+
+                if (Options.ImageEditorStartMode == ImageEditorStartMode.PreviousState)
+                {
+                    Options.ImageEditorWindowState.UpdateFormState(this);
+                }
+            }
+        }
+
+        internal bool ShowExitConfirmation()
+        {
+            bool result = true;
+
+            if (IsModified)
+            {
+                Pause();
+                result = MessageBox.Show(this, Resources.RegionCaptureForm_ShowExitConfirmation_Text, Resources.RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor,
+                    MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
+                Resume();
+            }
+
+            return result;
+        }
+
+        internal void RegionCaptureForm_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyData == Keys.Escape)
+            {
+                if (ShapeManager.HandleEscape())
+                {
+                    return;
+                }
+
+                if (!IsEditorMode || ShowExitConfirmation())
+                {
+                    CloseWindow();
+                }
+
+                return;
+            }
+
+            if (!isKeyAllowed && timerStart.ElapsedMilliseconds < 1000)
+            {
+                return;
+            }
+
+            isKeyAllowed = true;
+
+            switch (e.KeyData)
+            {
+                case Keys.Space:
+                    CloseWindow(RegionResult.Fullscreen);
+                    break;
+                case Keys.Enter:
+                    if (ShapeManager.IsCurrentShapeTypeRegion)
+                    {
+                        ShapeManager.StartRegionSelection();
+                        ShapeManager.EndRegionSelection();
+                    }
+
+                    CloseWindow(RegionResult.Region);
+                    break;
+                case Keys.Oemtilde:
+                    CloseWindow(RegionResult.ActiveMonitor);
+                    break;
+                case Keys.Control | Keys.C:
+                    CopyAreaInfo();
+                    break;
+            }
+
+            if (!IsEditorMode && e.KeyData >= Keys.D0 && e.KeyData <= Keys.D9)
+            {
+                MonitorKey(e.KeyData - Keys.D0);
+                return;
+            }
+        }
+
+        private void RegionCaptureForm_MouseDown(object sender, MouseEventArgs e)
+        {
+            if ((Mode == RegionCaptureMode.OneClick || Mode == RegionCaptureMode.ScreenColorPicker) && e.Button == MouseButtons.Left)
+            {
+                CurrentPosition = InputManager.MousePosition;
+
+                if (Mode == RegionCaptureMode.OneClick)
+                {
+                    SelectedWindow = ShapeManager.FindSelectedWindow();
+                }
+
+                CloseWindow(RegionResult.Region);
+            }
+        }
+
+        private void MonitorKey(int index)
+        {
+            if (index == 0)
+            {
+                index = 10;
+            }
+
+            index--;
+
+            MonitorIndex = index;
+
+            CloseWindow(RegionResult.Monitor);
+        }
+
+        internal void CloseWindow(RegionResult result = RegionResult.Close)
+        {
+            Result = result;
+            forceClose = true;
+            Close();
+        }
+
+        internal void Pause()
+        {
+            pause = true;
+        }
+
+        internal void Resume()
+        {
+            pause = false;
+
+            Invalidate();
+        }
+
+        private void CopyAreaInfo()
+        {
+            string clipboardText;
+
+            if (ShapeManager.IsCurrentShapeValid)
+            {
+                clipboardText = GetAreaText(ShapeManager.CurrentRectangle);
+            }
+            else
+            {
+                CurrentPosition = InputManager.MousePosition;
+                clipboardText = GetInfoText();
+            }
+
+            ClipboardHelpers.CopyText(clipboardText);
+        }
+
+        public WindowInfo GetWindowInfo()
+        {
+            return ShapeManager.FindSelectedWindowInfo(CurrentPosition);
+        }
+
+        public void AddCursor(IntPtr cursorHandle, Point position)
+        {
+            if (ShapeManager != null)
+            {
+                ShapeManager.AddCursor(cursorHandle, position);
+            }
+        }
+
+        private void UpdateCoordinates()
+        {
+            ClientArea = ClientRectangle;
+
+            InputManager.Update(this);
+        }
+
+        private new void Update()
+        {
+            if (!timerStart.IsRunning)
+            {
+                timerStart.Start();
+                timerFPS.Start();
+            }
+
+            UpdateCoordinates();
+
+            ShapeManager.UpdateObjects();
+
+            if (ShapeManager.IsPanning)
+            {
+                Pan(InputManager.MouseVelocity);
+                UpdateCenterOffset();
+            }
+
+            if (Options.EnableAnimations)
+            {
+                borderDotPen.DashOffset = (float)timerStart.Elapsed.TotalSeconds * -15;
+            }
+
+            ShapeManager.Update();
+        }
+
+        protected override void OnPaintBackground(PaintEventArgs e)
+        {
+            //base.OnPaintBackground(e);
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            Update();
+
+            Graphics g = e.Graphics;
+
+            if (IsEditorMode && !CanvasRectangle.Contains(ClientArea))
+            {
+                g.Clear(canvasBackgroundColor);
+                g.DrawRectangleProper(canvasBorderPen, CanvasRectangle.Offset(1));
+            }
+
+            g.CompositingMode = CompositingMode.SourceCopy;
+            g.FillRectangle(backgroundBrush, CanvasRectangle);
+            g.CompositingMode = CompositingMode.SourceOver;
+
+            Draw(g);
+
+            if (Options.ShowFPS)
+            {
+                CheckFPS();
+
+                if (IsFullscreen)
+                {
+                    DrawFPS(g, 10);
+                }
+            }
+
+            if (!pause)
+            {
+                Invalidate();
+            }
+        }
+
+        private void Draw(Graphics g)
+        {
+            // Draw snap rectangles
+            if (ShapeManager.IsCreating && ShapeManager.IsSnapResizing)
+            {
+                BaseShape shape = ShapeManager.CurrentShape;
+
+                if (shape != null && shape.ShapeType != ShapeType.RegionFreehand && shape.ShapeType != ShapeType.DrawingFreehand)
+                {
+                    foreach (Size size in Options.SnapSizes)
+                    {
+                        Rectangle snapRect = CaptureHelpers.CalculateNewRectangle(shape.StartPosition, shape.EndPosition, size);
+                        g.DrawRectangleProper(markerPen, snapRect);
+                    }
+                }
+            }
+
+            List<BaseShape> areas = ShapeManager.ValidRegions.ToList();
+
+            if (areas.Count > 0)
+            {
+                // Create graphics path from all regions
+                UpdateRegionPath();
+
+                // If background is dimmed then draw non dimmed background to region selections
+                if (!IsEditorMode && Options.UseDimming)
+                {
+                    using (Region region = new Region(regionDrawPath))
+                    {
+                        g.Clip = region;
+                        g.FillRectangle(backgroundHighlightBrush, ClientArea);
+                        g.ResetClip();
+                    }
+                }
+
+                g.DrawPath(borderPen, regionDrawPath);
+                g.DrawPath(borderDotStaticPen, regionDrawPath);
+            }
+
+            // Draw effect shapes
+            foreach (BaseEffectShape effectShape in ShapeManager.EffectShapes)
+            {
+                effectShape.OnDraw(g);
+            }
+
+            // Draw drawing shapes
+            foreach (BaseDrawingShape drawingShape in ShapeManager.DrawingShapes)
+            {
+                drawingShape.OnDraw(g);
+            }
+
+            // Draw tools
+            foreach (BaseTool toolShape in ShapeManager.ToolShapes)
+            {
+                toolShape.OnDraw(g);
+            }
+
+            // Draw animated rectangle on hover area
+            if (ShapeManager.IsCurrentHoverShapeValid)
+            {
+                if (Options.EnableAnimations)
+                {
+                    if (!ShapeManager.PreviousHoverRectangle.IsEmpty && ShapeManager.CurrentHoverShape.Rectangle != ShapeManager.PreviousHoverRectangle)
+                    {
+                        if (regionAnimation.CurrentRectangle.Width > 2 && regionAnimation.CurrentRectangle.Height > 2)
+                        {
+                            regionAnimation.FromRectangle = regionAnimation.CurrentRectangle;
+                        }
+                        else
+                        {
+                            regionAnimation.FromRectangle = ShapeManager.PreviousHoverRectangle;
+                        }
+
+                        regionAnimation.ToRectangle = ShapeManager.CurrentHoverShape.Rectangle;
+                        regionAnimation.Start();
+                    }
+
+                    regionAnimation.Update();
+                }
+
+                using (GraphicsPath hoverDrawPath = new GraphicsPath { FillMode = FillMode.Winding })
+                {
+                    if (Options.EnableAnimations && regionAnimation.IsActive && regionAnimation.CurrentRectangle.Width > 2 && regionAnimation.CurrentRectangle.Height > 2)
+                    {
+                        ShapeManager.CurrentHoverShape.OnShapePathRequested(hoverDrawPath, regionAnimation.CurrentRectangle.SizeOffset(-1));
+                    }
+                    else
+                    {
+                        ShapeManager.CurrentHoverShape.AddShapePath(hoverDrawPath, -1);
+                    }
+
+                    g.DrawPath(borderPen, hoverDrawPath);
+                    g.DrawPath(borderDotPen, hoverDrawPath);
+                }
+            }
+
+            // Draw animated rectangle on selection area
+            if (ShapeManager.IsCurrentShapeTypeRegion && ShapeManager.IsCurrentShapeValid)
+            {
+                if (Mode == RegionCaptureMode.Ruler)
+                {
+                    using (SolidBrush brush = new SolidBrush(Color.FromArgb(50, 255, 255, 255)))
+                    {
+                        g.FillRectangle(brush, ShapeManager.CurrentRectangle);
+                    }
+
+                    DrawRuler(g, ShapeManager.CurrentRectangle, borderPen, 5, 10);
+                    DrawRuler(g, ShapeManager.CurrentRectangle, borderPen, 15, 100);
+
+                    g.DrawCross(borderPen, ShapeManager.CurrentRectangle.Center(), 10);
+                }
+
+                DrawRegionArea(g, ShapeManager.CurrentRectangle, true);
+            }
+
+            // Draw all regions rectangle info
+            if (Options.ShowInfo)
+            {
+                // Add hover area to list so rectangle info can be shown
+                if (ShapeManager.IsCurrentShapeTypeRegion && ShapeManager.IsCurrentHoverShapeValid && areas.All(area => area.Rectangle != ShapeManager.CurrentHoverShape.Rectangle))
+                {
+                    areas.Add(ShapeManager.CurrentHoverShape);
+                }
+
+                foreach (BaseShape regionInfo in areas)
+                {
+                    if (regionInfo.Rectangle.IsValid())
+                    {
+                        string areaText = GetAreaText(regionInfo.Rectangle);
+                        DrawAreaText(g, areaText, regionInfo.Rectangle);
+                    }
+                }
+            }
+
+            // Draw resize nodes
+            ShapeManager.DrawObjects(g);
+
+            // Draw magnifier
+            if (Options.ShowMagnifier || Options.ShowInfo)
+            {
+                DrawCursorGraphics(g);
+            }
+
+            // Draw screen wide crosshair
+            if (Options.ShowCrosshair)
+            {
+                DrawCrosshair(g);
+            }
+
+            // Draw image editor bottom tip
+            if (IsEditorMode && Options.ShowEditorPanTip && editorPanTipAnimation != null && editorPanTipAnimation.Update())
+            {
+                DrawBottomTipAnimation(g, editorPanTipAnimation);
+            }
+
+            // Draw menu tooltips
+            if (IsAnnotationMode && ShapeManager.MenuTextAnimation.Update())
+            {
+                DrawTextAnimation(g, ShapeManager.MenuTextAnimation);
+            }
+        }
+
+        internal void DrawRegionArea(Graphics g, Rectangle rect, bool isAnimated)
+        {
+            g.DrawRectangleProper(borderPen, rect);
+
+            if (isAnimated)
+            {
+                g.DrawRectangleProper(borderDotPen, rect);
+            }
+            else
+            {
+                g.DrawRectangleProper(borderDotStaticPen, rect);
+            }
+        }
+
+        private void CheckFPS()
+        {
+            frameCount++;
+
+            if (timerFPS.ElapsedMilliseconds >= 1000)
+            {
+                FPS = (int)(frameCount / timerFPS.Elapsed.TotalSeconds);
+                frameCount = 0;
+                timerFPS.Reset();
+                timerFPS.Start();
+
+                if (!IsFullscreen)
+                {
+                    UpdateTitle();
+                }
+            }
+        }
+
+        private void DrawFPS(Graphics g, int offset)
+        {
+            Point textPosition = new Point(offset, offset);
+
+            if (IsFullscreen)
+            {
+                Rectangle rectScreen = CaptureHelpers.GetActiveScreenBounds0Based();
+                textPosition = textPosition.Add(rectScreen.Location);
+            }
+
+            g.DrawTextWithShadow(FPS.ToString(), textPosition, infoFontBig, Brushes.White, Brushes.Black, new Point(0, 1));
+        }
+
+        private void DrawInfoText(Graphics g, string text, Rectangle rect, Font font, int padding)
+        {
+            DrawInfoText(g, text, rect, font, new Point(padding, padding));
+        }
+
+        private void DrawInfoText(Graphics g, string text, Rectangle rect, Font font, Point padding)
+        {
+            DrawInfoText(g, text, rect, font, padding, textBackgroundBrush, textOuterBorderPen, textInnerBorderPen, textBrush, textShadowBrush);
+        }
+
+        private void DrawInfoText(Graphics g, string text, Rectangle rect, Font font, int padding,
+            Brush backgroundBrush, Pen outerBorderPen, Pen innerBorderPen, Brush textBrush, Brush textShadowBrush)
+        {
+            DrawInfoText(g, text, rect, font, new Point(padding, padding), backgroundBrush, outerBorderPen, innerBorderPen, textBrush, textShadowBrush);
+        }
+
+        private void DrawInfoText(Graphics g, string text, Rectangle rect, Font font, Point padding,
+            Brush backgroundBrush, Pen outerBorderPen, Pen innerBorderPen, Brush textBrush, Brush textShadowBrush)
+        {
+            g.FillRectangle(backgroundBrush, rect.Offset(-2));
+            g.DrawRectangleProper(innerBorderPen, rect.Offset(-1));
+            g.DrawRectangleProper(outerBorderPen, rect);
+
+            g.DrawTextWithShadow(text, rect.LocationOffset(padding.X, padding.Y).Location, font, textBrush, textShadowBrush);
+        }
+
+        internal void DrawAreaText(Graphics g, string text, Rectangle area)
+        {
+            int offset = 6;
+            int backgroundPadding = 3;
+            Size textSize = g.MeasureString(text, infoFont).ToSize();
+            Point textPos;
+
+            if (area.Y - offset - textSize.Height - (backgroundPadding * 2) < ClientArea.Y)
+            {
+                textPos = new Point(area.X + offset + backgroundPadding, area.Y + offset + backgroundPadding);
+            }
+            else
+            {
+                textPos = new Point(area.X + backgroundPadding, area.Y - offset - backgroundPadding - textSize.Height);
+            }
+
+            if (textPos.X + textSize.Width + backgroundPadding >= ClientArea.Width)
+            {
+                textPos.X = ClientArea.Width - textSize.Width - backgroundPadding;
+            }
+
+            Rectangle backgroundRect = new Rectangle(textPos.X - backgroundPadding, textPos.Y - backgroundPadding, textSize.Width + (backgroundPadding * 2), textSize.Height + (backgroundPadding * 2));
+
+            DrawInfoText(g, text, backgroundRect, infoFont, backgroundPadding);
+        }
+
+        private void DrawTextAnimation(Graphics g, TextAnimation textAnimation)
+        {
+            Size textSize = g.MeasureString(textAnimation.Text, infoFontMedium).ToSize();
+            int padding = 3;
+            textSize.Width += padding * 2;
+            textSize.Height += padding * 2;
+            Rectangle textRectangle = new Rectangle(textAnimation.Position.X, textAnimation.Position.Y, textSize.Width, textSize.Height);
+            DrawTextAnimation(g, textAnimation, textRectangle, padding);
+        }
+
+        private void DrawTextAnimation(Graphics g, TextAnimation textAnimation, Rectangle textRectangle, int padding)
+        {
+            using (Brush backgroundBrush = new SolidBrush(Color.FromArgb((int)(textAnimation.Opacity * 200), textBackgroundColor)))
+            using (Pen outerBorderPen = new Pen(Color.FromArgb((int)(textAnimation.Opacity * 200), textOuterBorderColor)))
+            using (Pen innerBorderPen = new Pen(Color.FromArgb((int)(textAnimation.Opacity * 200), textInnerBorderColor)))
+            using (Brush textBrush = new SolidBrush(Color.FromArgb((int)(textAnimation.Opacity * 255), textColor)))
+            using (Brush textShadowBrush = new SolidBrush(Color.FromArgb((int)(textAnimation.Opacity * 255), textShadowColor)))
+            {
+                DrawInfoText(g, textAnimation.Text, textRectangle, infoFontMedium, padding, backgroundBrush, outerBorderPen, innerBorderPen, textBrush, textShadowBrush);
+            }
+        }
+
+        private void DrawBottomTipAnimation(Graphics g, TextAnimation textAnimation)
+        {
+            Size textSize = g.MeasureString(textAnimation.Text, infoFontMedium).ToSize();
+            int padding = 5;
+            textSize.Width += padding * 2;
+            textSize.Height += padding * 2;
+            int margin = 20;
+            Rectangle textRectangle = new Rectangle((ClientArea.Width / 2) - (textSize.Width / 2), ClientArea.Height - textSize.Height - margin, textSize.Width, textSize.Height);
+            DrawTextAnimation(g, textAnimation, textRectangle, padding);
+        }
+
+        internal string GetAreaText(Rectangle rect)
+        {
+            if (IsEditorMode)
+            {
+                rect = new Rectangle(rect.X - CanvasRectangle.X, rect.Y - CanvasRectangle.Y, rect.Width, rect.Height);
+            }
+            else if (Mode == RegionCaptureMode.Ruler)
+            {
+                Point endLocation = new Point(rect.Right - 1, rect.Bottom - 1);
+                string text = $"X: {rect.X} | Y: {rect.Y} | Right: {endLocation.X} | Bottom: {endLocation.Y}\r\n" +
+                    $"Width: {rect.Width} px | Height: {rect.Height} px | Area: {rect.Area()} px | Perimeter: {rect.Perimeter()} px\r\n" +
+                    $"Distance: {MathHelpers.Distance(rect.Location, endLocation):0.00} px | Angle: {MathHelpers.LookAtDegree(rect.Location, endLocation):0.00}°";
+                return text;
+            }
+
+            return string.Format(Resources.RectangleRegion_GetAreaText_Area, rect.X, rect.Y, rect.Width, rect.Height);
+        }
+
+        private string GetInfoText()
+        {
+            if (IsEditorMode)
+            {
+                Point canvasRelativePosition = new Point(InputManager.ClientMousePosition.X - CanvasRectangle.X, InputManager.ClientMousePosition.Y - CanvasRectangle.Y);
+                return $"X: {canvasRelativePosition.X} Y: {canvasRelativePosition.Y}";
+            }
+            else if (Mode == RegionCaptureMode.ScreenColorPicker || Options.UseCustomInfoText)
+            {
+                Color color = ShapeManager.GetCurrentColor();
+
+                if (Mode == RegionCaptureMode.ScreenColorPicker)
+                {
+                    if (!string.IsNullOrEmpty(Options.ScreenColorPickerInfoText))
+                    {
+                        return CodeMenuEntryPixelInfo.Parse(Options.ScreenColorPickerInfoText, color, CurrentPosition);
+                    }
+                }
+                else if (!string.IsNullOrEmpty(Options.CustomInfoText))
+                {
+                    return CodeMenuEntryPixelInfo.Parse(Options.CustomInfoText, color, CurrentPosition);
+                }
+
+                return string.Format(Resources.RectangleRegion_GetColorPickerText, color.R, color.G, color.B, ColorHelpers.ColorToHex(color), CurrentPosition.X, CurrentPosition.Y);
+            }
+
+            return $"X: {CurrentPosition.X} Y: {CurrentPosition.Y}";
+        }
+
+        private void DrawCrosshair(Graphics g)
+        {
+            int offset = 5;
+            Point mousePos = InputManager.ClientMousePosition;
+            Point left = new Point(mousePos.X - offset, mousePos.Y), left2 = new Point(0, mousePos.Y);
+            Point right = new Point(mousePos.X + offset, mousePos.Y), right2 = new Point(ClientArea.Width - 1, mousePos.Y);
+            Point top = new Point(mousePos.X, mousePos.Y - offset), top2 = new Point(mousePos.X, 0);
+            Point bottom = new Point(mousePos.X, mousePos.Y + offset), bottom2 = new Point(mousePos.X, ClientArea.Height - 1);
+
+            if (left.X - left2.X > 10)
+            {
+                g.DrawLine(borderPen, left, left2);
+                g.DrawLine(borderDotPen, left, left2);
+            }
+
+            if (right2.X - right.X > 10)
+            {
+                g.DrawLine(borderPen, right, right2);
+                g.DrawLine(borderDotPen, right, right2);
+            }
+
+            if (top.Y - top2.Y > 10)
+            {
+                g.DrawLine(borderPen, top, top2);
+                g.DrawLine(borderDotPen, top, top2);
+            }
+
+            if (bottom2.Y - bottom.Y > 10)
+            {
+                g.DrawLine(borderPen, bottom, bottom2);
+                g.DrawLine(borderDotPen, bottom, bottom2);
+            }
+        }
+
+        private void DrawCursorGraphics(Graphics g)
+        {
+            Point mousePos = InputManager.ClientMousePosition;
+            Rectangle currentScreenRect0Based = CaptureHelpers.GetActiveScreenBounds0Based();
+            int cursorOffsetX = 10, cursorOffsetY = 10, itemGap = 10, itemCount = 0;
+            Size totalSize = Size.Empty;
+
+            int magnifierPosition = 0;
+            Bitmap magnifier = null;
+
+            if (Options.ShowMagnifier)
+            {
+                if (itemCount > 0) totalSize.Height += itemGap;
+                magnifierPosition = totalSize.Height;
+
+                magnifier = Magnifier(Canvas, mousePos, Options.MagnifierPixelCount, Options.MagnifierPixelCount, Options.MagnifierPixelSize);
+                totalSize.Width = Math.Max(totalSize.Width, magnifier.Width);
+
+                totalSize.Height += magnifier.Height;
+                itemCount++;
+            }
+
+            int infoTextPadding = 3;
+            int infoTextPosition = 0;
+            Rectangle infoTextRect = Rectangle.Empty;
+            string infoText = "";
+
+            if (Options.ShowInfo)
+            {
+                if (itemCount > 0) totalSize.Height += itemGap;
+                infoTextPosition = totalSize.Height;
+
+                CurrentPosition = InputManager.MousePosition;
+                infoText = GetInfoText();
+                Size textSize = g.MeasureString(infoText, infoFont).ToSize();
+                infoTextRect.Size = new Size(textSize.Width + (infoTextPadding * 2), textSize.Height + (infoTextPadding * 2));
+                totalSize.Width = Math.Max(totalSize.Width, infoTextRect.Width);
+
+                totalSize.Height += infoTextRect.Height;
+                itemCount++;
+            }
+
+            int x = mousePos.X + cursorOffsetX;
+
+            if (x + totalSize.Width > currentScreenRect0Based.Right)
+            {
+                x = mousePos.X - cursorOffsetX - totalSize.Width;
+            }
+
+            int y = mousePos.Y + cursorOffsetY;
+
+            if (y + totalSize.Height > currentScreenRect0Based.Bottom)
+            {
+                y = mousePos.Y - cursorOffsetY - totalSize.Height;
+            }
+
+            if (Options.ShowMagnifier)
+            {
+                using (GraphicsQualityManager quality = new GraphicsQualityManager(g))
+                using (TextureBrush brush = new TextureBrush(magnifier))
+                {
+                    brush.TranslateTransform(x, y + magnifierPosition);
+
+                    if (Options.UseSquareMagnifier)
+                    {
+                        g.FillRectangle(brush, x, y + magnifierPosition, magnifier.Width, magnifier.Height);
+                        g.DrawRectangleProper(Pens.White, x - 1, y + magnifierPosition - 1, magnifier.Width + 2, magnifier.Height + 2);
+                        g.DrawRectangleProper(Pens.Black, x, y + magnifierPosition, magnifier.Width, magnifier.Height);
+                    }
+                    else
+                    {
+                        g.FillEllipse(brush, x, y + magnifierPosition, magnifier.Width, magnifier.Height);
+                        g.DrawEllipse(Pens.White, x - 1, y + magnifierPosition - 1, magnifier.Width + 2 - 1, magnifier.Height + 2 - 1);
+                        g.DrawEllipse(Pens.Black, x, y + magnifierPosition, magnifier.Width - 1, magnifier.Height - 1);
+                    }
+                }
+            }
+
+            if (Options.ShowInfo)
+            {
+                if (Mode == RegionCaptureMode.ScreenColorPicker)
+                {
+                    int colorBoxOffset = 2;
+                    int colorBoxSize = infoTextRect.Height - (colorBoxOffset * 2);
+                    int textOffset = 4;
+                    int colorBoxExtraWidth = colorBoxSize + textOffset;
+                    infoTextRect.Width += colorBoxExtraWidth;
+                    infoTextRect.Location = new Point(x + (totalSize.Width / 2) - (infoTextRect.Width / 2), y + infoTextPosition);
+                    Point padding = new Point(infoTextPadding + colorBoxExtraWidth, infoTextPadding);
+
+                    Rectangle colorRect = new Rectangle(infoTextRect.X + colorBoxOffset, infoTextRect.Y + colorBoxOffset, colorBoxSize, colorBoxSize);
+
+                    DrawInfoText(g, infoText, infoTextRect, infoFont, padding);
+
+                    using (Brush colorBrush = new SolidBrush(ShapeManager.GetCurrentColor()))
+                    {
+                        g.FillRectangle(colorBrush, colorRect);
+                    }
+
+                    g.DrawLine(textInnerBorderPen, colorRect.Right, colorRect.Top, colorRect.Right, colorRect.Bottom - 1);
+                }
+                else
+                {
+                    infoTextRect.Location = new Point(x + (totalSize.Width / 2) - (infoTextRect.Width / 2), y + infoTextPosition);
+                    Point padding = new Point(infoTextPadding, infoTextPadding);
+
+                    DrawInfoText(g, infoText, infoTextRect, infoFont, padding);
+                }
+            }
+        }
+
+        private Bitmap Magnifier(Image img, Point position, int horizontalPixelCount, int verticalPixelCount, int pixelSize)
+        {
+            horizontalPixelCount = (horizontalPixelCount | 1).Clamp(1, 101);
+            verticalPixelCount = (verticalPixelCount | 1).Clamp(1, 101);
+            pixelSize = pixelSize.Clamp(1, 1000);
+
+            if (horizontalPixelCount * pixelSize > ClientArea.Width || verticalPixelCount * pixelSize > ClientArea.Height)
+            {
+                horizontalPixelCount = verticalPixelCount = 15;
+                pixelSize = 10;
+            }
+
+            int width = horizontalPixelCount * pixelSize;
+            int height = verticalPixelCount * pixelSize;
+            Bitmap bmp = new Bitmap(width - 1, height - 1);
+
+            using (Graphics g = Graphics.FromImage(bmp))
+            {
+                g.InterpolationMode = InterpolationMode.NearestNeighbor;
+                g.PixelOffsetMode = PixelOffsetMode.Half;
+
+                g.DrawImage(img, new Rectangle(0, 0, width, height), new Rectangle(position.X - (horizontalPixelCount / 2) - CanvasRectangle.X,
+                    position.Y - (verticalPixelCount / 2) - CanvasRectangle.Y, horizontalPixelCount, verticalPixelCount), GraphicsUnit.Pixel);
+
+                g.PixelOffsetMode = PixelOffsetMode.None;
+
+                using (SolidBrush crosshairBrush = new SolidBrush(Color.FromArgb(125, Color.LightBlue)))
+                {
+                    g.FillRectangle(crosshairBrush, new Rectangle(0, (height - pixelSize) / 2, (width - pixelSize) / 2, pixelSize)); // Left
+                    g.FillRectangle(crosshairBrush, new Rectangle((width + pixelSize) / 2, (height - pixelSize) / 2, (width - pixelSize) / 2, pixelSize)); // Right
+                    g.FillRectangle(crosshairBrush, new Rectangle((width - pixelSize) / 2, 0, pixelSize, (height - pixelSize) / 2)); // Top
+                    g.FillRectangle(crosshairBrush, new Rectangle((width - pixelSize) / 2, (height + pixelSize) / 2, pixelSize, (height - pixelSize) / 2)); // Bottom
+                }
+
+                using (Pen pen = new Pen(Color.FromArgb(75, Color.Black)))
+                {
+                    for (int x = 1; x < horizontalPixelCount; x++)
+                    {
+                        g.DrawLine(pen, new Point((x * pixelSize) - 1, 0), new Point((x * pixelSize) - 1, height - 1));
+                    }
+
+                    for (int y = 1; y < verticalPixelCount; y++)
+                    {
+                        g.DrawLine(pen, new Point(0, (y * pixelSize) - 1), new Point(width - 1, (y * pixelSize) - 1));
+                    }
+                }
+
+                g.DrawRectangle(Pens.Black, ((width - pixelSize) / 2) - 1, ((height - pixelSize) / 2) - 1, pixelSize, pixelSize);
+
+                if (pixelSize >= 6)
+                {
+                    g.DrawRectangle(Pens.White, (width - pixelSize) / 2, (height - pixelSize) / 2, pixelSize - 2, pixelSize - 2);
+                }
+            }
+
+            return bmp;
+        }
+
+        private void DrawRuler(Graphics g, Rectangle rect, Pen pen, int rulerSize, int rulerWidth)
+        {
+            if (rect.Width >= rulerSize && rect.Height >= rulerSize)
+            {
+                for (int x = 1; x <= rect.Width / rulerWidth; x++)
+                {
+                    g.DrawLine(pen, new Point(rect.X + (x * rulerWidth), rect.Y), new Point(rect.X + (x * rulerWidth), rect.Y + rulerSize));
+                    g.DrawLine(pen, new Point(rect.X + (x * rulerWidth), rect.Bottom), new Point(rect.X + (x * rulerWidth), rect.Bottom - rulerSize));
+                }
+
+                for (int y = 1; y <= rect.Height / rulerWidth; y++)
+                {
+                    g.DrawLine(pen, new Point(rect.X, rect.Y + (y * rulerWidth)), new Point(rect.X + rulerSize, rect.Y + (y * rulerWidth)));
+                    g.DrawLine(pen, new Point(rect.Right, rect.Y + (y * rulerWidth)), new Point(rect.Right - rulerSize, rect.Y + (y * rulerWidth)));
+                }
+            }
+        }
+
+        internal void UpdateRegionPath()
+        {
+            if (regionFillPath != null)
+            {
+                regionFillPath.Dispose();
+                regionFillPath = null;
+            }
+
+            if (regionDrawPath != null)
+            {
+                regionDrawPath.Dispose();
+                regionDrawPath = null;
+            }
+
+            BaseShape[] areas = ShapeManager.ValidRegions;
+
+            if (areas != null && areas.Length > 0)
+            {
+                regionFillPath = new GraphicsPath { FillMode = FillMode.Winding };
+                regionDrawPath = new GraphicsPath { FillMode = FillMode.Winding };
+
+                foreach (BaseShape regionShape in ShapeManager.ValidRegions)
+                {
+                    regionShape.AddShapePath(regionFillPath);
+                    regionShape.AddShapePath(regionDrawPath, -1);
+                }
+            }
+        }
+
+        public Bitmap GetResultImage()
+        {
+            if (IsEditorMode)
+            {
+                return ShapeManager.RenderOutputImage(Canvas, CanvasRectangle.Location);
+            }
+            else if (Result == RegionResult.Region || Result == RegionResult.LastRegion)
+            {
+                GraphicsPath gp;
+
+                if (Result == RegionResult.LastRegion)
+                {
+                    gp = LastRegionFillPath;
+                }
+                else
+                {
+                    gp = regionFillPath;
+                }
+
+                if (gp != null)
+                {
+                    using (Bitmap bmp = RegionCaptureTasks.ApplyRegionPathToImage(Canvas, gp, out Rectangle rect))
+                    {
+                        return ShapeManager.RenderOutputImage(bmp, rect.Location);
+                    }
+                }
+            }
+            else if (Result == RegionResult.Fullscreen)
+            {
+                return ShapeManager.RenderOutputImage(Canvas);
+            }
+            else if (Result == RegionResult.Monitor)
+            {
+                Screen[] screens = Screen.AllScreens;
+
+                if (MonitorIndex < screens.Length)
+                {
+                    Screen screen = screens[MonitorIndex];
+                    Rectangle screenRect = CaptureHelpers.ScreenToClient(screen.Bounds);
+
+                    using (Bitmap bmp = ShapeManager.RenderOutputImage(Canvas))
+                    {
+                        return ImageHelpers.CropBitmap(bmp, screenRect);
+                    }
+                }
+            }
+            else if (Result == RegionResult.ActiveMonitor)
+            {
+                Rectangle activeScreenRect = CaptureHelpers.GetActiveScreenBounds0Based();
+
+                using (Bitmap bmp = ShapeManager.RenderOutputImage(Canvas))
+                {
+                    return ImageHelpers.CropBitmap(bmp, activeScreenRect);
+                }
+            }
+
+            return null;
+        }
+
+        private Bitmap ReceiveImageForTask()
+        {
+            Bitmap bmp = GetResultImage();
+
+            ShapeManager.IsModified = false;
+
+            if (Options.AutoCloseEditorOnTask)
+            {
+                CloseWindow();
+            }
+
+            return bmp;
+        }
+
+        internal void OnSaveImageRequested()
+        {
+            if (SaveImageRequested != null)
+            {
+                Bitmap bmp = ReceiveImageForTask();
+
+                string imageFilePath = SaveImageRequested(bmp, ImageFilePath);
+
+                if (!string.IsNullOrEmpty(imageFilePath))
+                {
+                    ImageFilePath = imageFilePath;
+                    UpdateTitle();
+                    ShapeManager.ShowMenuTooltip(Resources.ImageSaved);
+                }
+            }
+        }
+
+        internal void OnSaveImageAsRequested()
+        {
+            if (SaveImageAsRequested != null)
+            {
+                Bitmap bmp = ReceiveImageForTask();
+
+                string imageFilePath = SaveImageAsRequested(bmp, ImageFilePath);
+
+                if (!string.IsNullOrEmpty(imageFilePath))
+                {
+                    ImageFilePath = imageFilePath;
+                    UpdateTitle();
+                    ShapeManager.ShowMenuTooltip(Resources.ImageSavedAs);
+                }
+            }
+        }
+
+        internal void OnCopyImageRequested()
+        {
+            if (CopyImageRequested != null)
+            {
+                Bitmap bmp = ReceiveImageForTask();
+
+                CopyImageRequested(bmp);
+                ShapeManager.ShowMenuTooltip(Resources.ImageCopied);
+            }
+        }
+
+        internal void OnUploadImageRequested()
+        {
+            if (UploadImageRequested != null)
+            {
+                Bitmap bmp = ReceiveImageForTask();
+
+                UploadImageRequested(bmp);
+                ShapeManager.ShowMenuTooltip(Resources.ImageUploading);
+            }
+        }
+
+        internal void OnPrintImageRequested()
+        {
+            if (PrintImageRequested != null)
+            {
+                Bitmap bmp = ReceiveImageForTask();
+
+                PrintImageRequested(bmp);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsClosing = true;
+
+            ShapeManager?.Dispose();
+            backgroundBrush?.Dispose();
+            backgroundHighlightBrush?.Dispose();
+            borderPen?.Dispose();
+            borderDotPen?.Dispose();
+            borderDotStaticPen?.Dispose();
+            infoFont?.Dispose();
+            infoFontMedium?.Dispose();
+            infoFontBig?.Dispose();
+            textBrush?.Dispose();
+            textShadowBrush?.Dispose();
+            textBackgroundBrush?.Dispose();
+            textOuterBorderPen?.Dispose();
+            textInnerBorderPen?.Dispose();
+            markerPen?.Dispose();
+            canvasBorderPen?.Dispose();
+            defaultCursor?.Dispose();
+            openHandCursor?.Dispose();
+            closedHandCursor?.Dispose();
+            CustomNodeImage?.Dispose();
+
+            if (regionFillPath != null)
+            {
+                if (Result == RegionResult.Region)
+                {
+                    LastRegionFillPath?.Dispose();
+                    LastRegionFillPath = regionFillPath;
+                }
+                else
+                {
+                    regionFillPath.Dispose();
+                }
+            }
+
+            regionDrawPath?.Dispose();
+            DimmedCanvas?.Dispose();
+            Canvas?.Dispose();
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/CodeModel.Tests/DataFactories/TestClasses/JSONExporter/ScreenRecorder.txt
+++ b/CodeModel.Tests/DataFactories/TestClasses/JSONExporter/ScreenRecorder.txt
@@ -1,0 +1,307 @@
+﻿#region License Information (GPL v3)
+
+/*
+    ShareX - A program that allows you to take screenshots and share any file type
+    Copyright (c) 2007-2020 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using ShareX.HelpersLib;
+using ShareX.MediaLib;
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Threading;
+
+namespace ShareX.ScreenCaptureLib
+{
+    public class ScreenRecorder : IDisposable
+    {
+        public bool IsRecording { get; private set; }
+
+        public int FPS
+        {
+            get
+            {
+                return fps;
+            }
+            set
+            {
+                if (!IsRecording)
+                {
+                    fps = value;
+                    UpdateInfo();
+                }
+            }
+        }
+
+        public float DurationSeconds
+        {
+            get
+            {
+                return durationSeconds;
+            }
+            set
+            {
+                if (!IsRecording)
+                {
+                    durationSeconds = value;
+                    UpdateInfo();
+                }
+            }
+        }
+
+        public Rectangle CaptureRectangle
+        {
+            get
+            {
+                return captureRectangle;
+            }
+            private set
+            {
+                if (!IsRecording)
+                {
+                    captureRectangle = value;
+                }
+            }
+        }
+
+        public string CachePath { get; private set; }
+
+        public ScreenRecordOutput OutputType { get; private set; }
+
+        public ScreencastOptions Options { get; set; }
+
+        public event Action RecordingStarted;
+
+        public delegate void ProgressEventHandler(int progress);
+        public event ProgressEventHandler EncodingProgressChanged;
+
+        private int fps, delay, frameCount, previousProgress;
+        private float durationSeconds;
+        private Screenshot screenshot;
+        private Rectangle captureRectangle;
+        private ImageCache imgCache;
+        private FFmpegCLIManager ffmpeg;
+        private bool stopRequested;
+
+        public ScreenRecorder(ScreenRecordOutput outputType, ScreencastOptions options, Screenshot screenshot, Rectangle captureRectangle)
+        {
+            if (string.IsNullOrEmpty(options.OutputPath))
+            {
+                throw new Exception("Screen recorder cache path is empty.");
+            }
+
+            FPS = options.FPS;
+            DurationSeconds = options.Duration;
+            CaptureRectangle = captureRectangle;
+            CachePath = options.OutputPath;
+            OutputType = outputType;
+
+            Options = options;
+
+            switch (OutputType)
+            {
+                default:
+                case ScreenRecordOutput.FFmpeg:
+                    Helpers.CreateDirectoryFromFilePath(Options.OutputPath);
+                    ffmpeg = new FFmpegCLIManager(Options.FFmpeg.FFmpegPath);
+                    ffmpeg.ShowError = true;
+                    ffmpeg.EncodeStarted += OnRecordingStarted;
+                    ffmpeg.EncodeProgressChanged += OnEncodingProgressChanged;
+                    break;
+                case ScreenRecordOutput.GIF:
+                    imgCache = new HardDiskCache(Options);
+                    break;
+            }
+
+            this.screenshot = screenshot;
+        }
+
+        private void UpdateInfo()
+        {
+            delay = 1000 / fps;
+            frameCount = (int)(fps * durationSeconds);
+        }
+
+        public void StartRecording()
+        {
+            if (!IsRecording)
+            {
+                IsRecording = true;
+                stopRequested = false;
+
+                if (OutputType == ScreenRecordOutput.FFmpeg)
+                {
+                    ffmpeg.Run(Options.GetFFmpegCommands());
+                }
+                else
+                {
+                    OnRecordingStarted();
+                    RecordUsingCache();
+                }
+            }
+
+            IsRecording = false;
+        }
+
+        private void RecordUsingCache()
+        {
+            try
+            {
+                for (int i = 0; !stopRequested && (frameCount == 0 || i < frameCount); i++)
+                {
+                    Stopwatch timer = Stopwatch.StartNew();
+
+                    Image img = screenshot.CaptureRectangle(CaptureRectangle);
+                    //DebugHelper.WriteLine("Screen capture: " + (int)timer.ElapsedMilliseconds);
+
+                    imgCache.AddImageAsync(img);
+
+                    if (!stopRequested && (frameCount == 0 || i + 1 < frameCount))
+                    {
+                        int sleepTime = delay - (int)timer.ElapsedMilliseconds;
+
+                        if (sleepTime > 0)
+                        {
+                            Thread.Sleep(sleepTime);
+                        }
+                        else if (sleepTime < 0)
+                        {
+                            // Need to handle FPS drops
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                imgCache.Finish();
+            }
+        }
+
+        public void StopRecording()
+        {
+            stopRequested = true;
+
+            if (ffmpeg != null)
+            {
+                ffmpeg.Close();
+            }
+        }
+
+        public void SaveAsGIF(string path, GIFQuality quality)
+        {
+            if (imgCache != null && imgCache is HardDiskCache && !IsRecording)
+            {
+                Helpers.CreateDirectoryFromFilePath(path);
+
+                HardDiskCache hdCache = imgCache as HardDiskCache;
+
+                using (AnimatedGifCreator gifEncoder = new AnimatedGifCreator(path, delay))
+                {
+                    int i = 0;
+                    int count = hdCache.Count;
+
+                    foreach (Image img in hdCache.GetImageEnumerator())
+                    {
+                        i++;
+                        OnEncodingProgressChanged((int)((float)i / count * 100));
+
+                        using (img)
+                        {
+                            gifEncoder.AddFrame(img, quality);
+                        }
+                    }
+                }
+            }
+        }
+
+        public bool FFmpegEncodeVideo(string input, string output)
+        {
+            Helpers.CreateDirectoryFromFilePath(output);
+
+            Options.IsRecording = false;
+            Options.IsLossless = false;
+            Options.InputPath = input;
+            Options.OutputPath = output;
+
+            try
+            {
+                ffmpeg.TrackEncodeProgress = true;
+
+                return ffmpeg.Run(Options.GetFFmpegCommands());
+            }
+            finally
+            {
+                ffmpeg.TrackEncodeProgress = false;
+            }
+        }
+
+        public bool FFmpegEncodeAsGIF(string input, string output)
+        {
+            Helpers.CreateDirectoryFromFilePath(output);
+
+            try
+            {
+                ffmpeg.TrackEncodeProgress = true;
+
+                // https://ffmpeg.org/ffmpeg-filters.html#palettegen-1
+                // https://ffmpeg.org/ffmpeg-filters.html#paletteuse
+                return ffmpeg.Run($"-i \"{input}\" -lavfi \"palettegen=stats_mode={Options.FFmpeg.GIFStatsMode}[palette]," +
+                    $"[0:v][palette]paletteuse=dither={Options.FFmpeg.GIFDither}" +
+                    $"{(Options.FFmpeg.GIFDither == FFmpegPaletteUseDither.bayer ? ":bayer_scale=" + Options.FFmpeg.GIFBayerScale : "")}\"" +
+                    $" -y \"{output}\"");
+            }
+            finally
+            {
+                ffmpeg.TrackEncodeProgress = false;
+            }
+        }
+
+        protected void OnRecordingStarted()
+        {
+            RecordingStarted?.Invoke();
+        }
+
+        protected void OnEncodingProgressChanged(float progress)
+        {
+            int currentProgress = (int)progress;
+
+            if (EncodingProgressChanged != null && currentProgress != previousProgress)
+            {
+                EncodingProgressChanged(currentProgress);
+                previousProgress = currentProgress;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (ffmpeg != null)
+            {
+                ffmpeg.Dispose();
+            }
+
+            if (imgCache != null)
+            {
+                imgCache.Dispose();
+            }
+        }
+    }
+}

--- a/CodeModel.Tests/Integration/JSONExporterTests.cs
+++ b/CodeModel.Tests/Integration/JSONExporterTests.cs
@@ -39,6 +39,18 @@ namespace CodeModel.Tests.Integration
                 TestDataFactory.ReadClassFromFile(
                     "../../../DataFactories/TestClasses/JSONExporter/RegionCaptureForm.txt"),
                 "C:\\CCaDET-Tests\\CodeModel\\JSONExporter\\RegionCaptureForm.json"
+            },
+            new object[]
+            {
+                TestDataFactory.ReadClassFromFile(
+                    "../../../DataFactories/TestClasses/JSONExporter/ScreenRecorder.txt"),
+                "C:\\CCaDET-Tests\\CodeModel\\JSONExporter\\ScreenRecorder.json"
+            },
+            new object[]
+            {
+                TestDataFactory.ReadClassFromFile(
+                    "../../../DataFactories/TestClasses/JSONExporter/BoxDecoratorViewModel.txt"),
+                "C:\\CCaDET-Tests\\CodeModel\\JSONExporter\\BoxDecoratorViewModel.json"
             }
         };
     }

--- a/CodeModel.Tests/Integration/JSONExporterTests.cs
+++ b/CodeModel.Tests/Integration/JSONExporterTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CodeModel.Exporters;
+using CodeModel.Tests.DataFactories;
+using Shouldly;
+using Xunit;
+
+namespace CodeModel.Tests.Integration
+{
+    public class JSONExporterTests
+    {
+        private static readonly CodeFactory TestDataFactory = new();
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public void Saves_class_to_json(IEnumerable<string> sourceCode, string jsonPath)
+        {
+            var exporter = new JSONExporter();
+            var project = new CodeModelFactory().CreateProject(sourceCode);
+            var actualClass = project.Classes.First();
+
+            exporter.ExportClassCohesionGraph(actualClass, jsonPath);
+
+            File.Exists(jsonPath).ShouldBeTrue();
+        }
+
+        public static IEnumerable<object[]> TestData => new List<object[]>
+        {
+            new object[]
+            {
+                //TODO: Establish convention for tests that rely on file system across project
+                TestDataFactory.ReadClassFromFile(
+                    "../../../DataFactories/TestClasses/JSONExporter/IntegrationHelpers.txt"),
+                "C:\\CCaDET-Tests\\CodeModel\\JSONExporter\\IntegrationHelpers.json"
+            },
+            new object[]
+            {
+                TestDataFactory.ReadClassFromFile(
+                    "../../../DataFactories/TestClasses/JSONExporter/RegionCaptureForm.txt"),
+                "C:\\CCaDET-Tests\\CodeModel\\JSONExporter\\RegionCaptureForm.json"
+            }
+        };
+    }
+}

--- a/CodeModel.Tests/Unit/CohesionCalculationTests.cs
+++ b/CodeModel.Tests/Unit/CohesionCalculationTests.cs
@@ -1,15 +1,12 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using CodeModel.CaDETModel.CodeItems;
+﻿using CodeModel.CaDETModel.CodeItems;
 using CodeModel.Tests.DataFactories;
 using Shouldly;
+using System.Collections.Generic;
 using Xunit;
 
 namespace CodeModel.Tests.Unit
 {
-    public class CohessionCalculationTests
+    public class CohesionCalculationTests
     {
         private static readonly CodeFactory _testDataFactory = new CodeFactory();
 
@@ -67,35 +64,35 @@ namespace CodeModel.Tests.Unit
             {
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/Level.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/Level.txt"),
                     "Level",
                     0.928
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteReader.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteReader.txt"),
                     "AsepriteReader",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteFile.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteFile.txt"),
                     "AsepriteFile",
                     0.889
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteWriter.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteWriter.txt"),
                     "AsepriteWriter",
                     -1
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AudioWriter.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AudioWriter.txt"),
                     "AudioWriter",
                     -1
                 }
@@ -107,35 +104,35 @@ namespace CodeModel.Tests.Unit
             {
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/Level.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/Level.txt"),
                     "Level",
                     0.17
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteReader.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteReader.txt"),
                     "AsepriteReader",
                     -1
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteFile.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteFile.txt"),
                     "AsepriteFile",
                     -1
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteWriter.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteWriter.txt"),
                     "AsepriteWriter",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AudioWriter.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AudioWriter.txt"),
                     "AudioWriter",
                     0
                 }
@@ -147,35 +144,35 @@ namespace CodeModel.Tests.Unit
             {
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/Level.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/Level.txt"),
                     "Level",
                     0.941
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteReader.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteReader.txt"),
                     "AsepriteReader",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteFile.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteFile.txt"),
                     "AsepriteFile",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteWriter.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteWriter.txt"),
                     "AsepriteWriter",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AudioWriter.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AudioWriter.txt"),
                     "AudioWriter",
                     0
                 }
@@ -187,35 +184,35 @@ namespace CodeModel.Tests.Unit
             {
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/Level.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/Level.txt"),
                     "Level",
                     9
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteReader.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteReader.txt"),
                     "AsepriteReader",
                     1
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteFile.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteFile.txt"),
                     "AsepriteFile",
                     1
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteWriter.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteWriter.txt"),
                     "AsepriteWriter",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AudioWriter.txt"),
+                    _testDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AudioWriter.txt"),
                     "AudioWriter",
                     0
                 }

--- a/CodeModel.Tests/Unit/MetricCalculationTests.cs
+++ b/CodeModel.Tests/Unit/MetricCalculationTests.cs
@@ -9,14 +9,14 @@ namespace CodeModel.Tests.Unit
 {
     public class MetricCalculationTests
     {
-        private static readonly CodeFactory _testDataFactory = new CodeFactory();
+        private static readonly CodeFactory TestDataFactory = new();
 
         [Fact]
         public void Calculates_lines_of_code_for_CSharp_class_elements()
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetDoctorClassText()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetDoctorClassText()).Classes;
 
             var doctorClass = classes.First();
             doctorClass.Metrics[CaDETMetric.CLOC].ShouldBe(22);
@@ -29,7 +29,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetGitAdapterClassText()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetGitAdapterClassText()).Classes;
 
             var gitClass = classes.First();
             gitClass.Metrics[CaDETMetric.WMC].ShouldBe(17);
@@ -41,7 +41,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetATFDMultipleClassTexts()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetATFDMultipleClassTexts()).Classes;
 
             var class1 = classes.Find(c => c.Name.Equals("Class1"));
             var class3 = classes.Find(c => c.Name.Equals("Class3"));
@@ -61,7 +61,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.Metrics[CaDETMetric.CNOR].ShouldBe(3);
@@ -72,7 +72,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.Metrics[CaDETMetric.CNOL].ShouldBe(7);
@@ -83,7 +83,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.Metrics[CaDETMetric.CNOC].ShouldBe(7);
@@ -94,7 +94,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.Metrics[CaDETMetric.CNOA].ShouldBe(2);
@@ -105,7 +105,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.Metrics[CaDETMetric.NOPM].ShouldBe(3);
@@ -116,7 +116,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.Metrics[CaDETMetric.NOPF].ShouldBe(2);
@@ -127,7 +127,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.Metrics[CaDETMetric.CMNB].ShouldBe(4);
@@ -138,7 +138,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetMultipleClassTexts()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetMultipleClassTexts()).Classes;
 
             var dataRange = classes.Find(c => c.Name.Equals("DateRange"));
             var doctor = classes.Find(c => c.Name.Equals("Doctor"));
@@ -167,35 +167,35 @@ namespace CodeModel.Tests.Unit
             {
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/Level.txt"),
+                    TestDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/Level.txt"),
                     "Level",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteReader.txt"),
+                    TestDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteReader.txt"),
                     "AsepriteReader",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteFile.txt"),
+                    TestDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteFile.txt"),
                     "AsepriteFile",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteWriter.txt"),
+                    TestDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteWriter.txt"),
                     "AsepriteWriter",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AudioWriter.txt"),
+                    TestDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AudioWriter.txt"),
                     "AudioWriter",
                     0
                 }
@@ -219,35 +219,35 @@ namespace CodeModel.Tests.Unit
             {
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/Level.txt"),
+                    TestDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/Level.txt"),
                     "Level",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteReader.txt"),
+                    TestDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteReader.txt"),
                     "AsepriteReader",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteFile.txt"),
+                    TestDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteFile.txt"),
                     "AsepriteFile",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteWriter.txt"),
+                    TestDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AsepriteWriter.txt"),
                     "AsepriteWriter",
                     0
                 },
 
                 new object[]
                 {
-                    _testDataFactory.readClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AudioWriter.txt"),
+                    TestDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/SmellyClasses/AudioWriter.txt"),
                     "AudioWriter",
                     0
                 }
@@ -258,7 +258,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetMultipleClassTexts()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetMultipleClassTexts()).Classes;
 
             var dateRange = classes.Find(c => c.Name.Equals("DateRange"));
             var service = classes.Find(c => c.Name.Equals("DoctorService"));
@@ -272,7 +272,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetGitAdapterClassText()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetGitAdapterClassText()).Classes;
 
             var gitClass = classes.First();
 
@@ -285,7 +285,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetEffectiveLinesOfCodeTest()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetEffectiveLinesOfCodeTest()).Classes;
 
             var doctor = classes.First();
             doctor.FindMember("Doctor").Metrics[CaDETMetric.MELOC].ShouldBe(1);
@@ -297,7 +297,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetGitAdapterClassText()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetGitAdapterClassText()).Classes;
 
             var gitClass = classes.First();
             gitClass.FindMember("CheckForNewCommits").Metrics[CaDETMetric.NOP].ShouldBe(0);
@@ -311,7 +311,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetGitAdapterClassText()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetGitAdapterClassText()).Classes;
 
             var gitClass = classes.First();
             gitClass.FindMember("CheckForNewCommits").Metrics[CaDETMetric.NOLV].ShouldBe(2);
@@ -323,7 +323,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.FindMember("CSharpCodeParserInit").Metrics[CaDETMetric.NOTC].ShouldBe(0);
@@ -337,7 +337,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.FindMember("CSharpCodeParserInit").Metrics[CaDETMetric.MNOL].ShouldBe(0);
@@ -351,7 +351,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.FindMember("CSharpCodeParserInit").Metrics[CaDETMetric.MNOR].ShouldBe(0);
@@ -364,7 +364,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.FindMember("CSharpCodeParserInit").Metrics[CaDETMetric.MNOC].ShouldBe(0);
@@ -377,7 +377,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.FindMember("CSharpCodeParserInit").Metrics[CaDETMetric.MNOA].ShouldBe(2);
@@ -389,7 +389,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.FindMember("CSharpCodeParserInit").Metrics[CaDETMetric.NONL].ShouldBe(4);
@@ -402,7 +402,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.FindMember("CSharpCodeParserInit").Metrics[CaDETMetric.NOSL].ShouldBe(1);
@@ -415,7 +415,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.FindMember("CSharpCodeParserInit").Metrics[CaDETMetric.NOMO].ShouldBe(2);
@@ -428,7 +428,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.FindMember("CSharpCodeParserInit").Metrics[CaDETMetric.NOPE].ShouldBe(0);
@@ -440,7 +440,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.FindMember("CSharpCodeParserInit").Metrics[CaDETMetric.NOLE].ShouldBe(0);
@@ -452,7 +452,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var firstClass = classes.First();
             firstClass.FindMember("CSharpCodeParserInit").Metrics[CaDETMetric.MMNB].ShouldBe(0);
@@ -466,7 +466,7 @@ namespace CodeModel.Tests.Unit
         {
             CodeModelFactory factory = new CodeModelFactory();
 
-            List<CaDETClass> classes = factory.CreateProject(_testDataFactory.GetCodeBlocksClass()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCodeBlocksClass()).Classes;
 
             var gitClass = classes.First();
             gitClass.FindMember("CSharpCodeParserInit").Metrics[CaDETMetric.NOUW].ShouldBe(5);

--- a/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
+++ b/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
@@ -22,6 +22,14 @@ namespace CodeModel.CaDETModel.CodeItems
         {
             var signatureBuilder = new StringBuilder();
             if (Parent != null) signatureBuilder.Append(Parent.FullName).Append(".");
+            signatureBuilder.Append(GetMethodNameWithParamTypes());
+
+            return signatureBuilder.ToString();
+        }
+
+        internal string GetMethodNameWithParamTypes()
+        {
+            StringBuilder signatureBuilder = new StringBuilder();
             signatureBuilder.Append(Name);
             if (Params != null)
             {
@@ -31,6 +39,7 @@ namespace CodeModel.CaDETModel.CodeItems
                     signatureBuilder.Append(Params[i].Type.FullType);
                     if (i < Params.Count - 1) signatureBuilder.Append(", ");
                 }
+
                 signatureBuilder.Append(")");
             }
 

--- a/CodeModel/Exporters/JSONExporter.cs
+++ b/CodeModel/Exporters/JSONExporter.cs
@@ -1,0 +1,68 @@
+﻿using CodeModel.CaDETModel.CodeItems;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace CodeModel.Exporters
+{
+    public class JSONExporter
+    {
+        public void ExportClassCohesionGraph(CaDETClass caDetClass, string filePath)
+        {
+            var graph = GetClassCohesionGraph(caDetClass);
+            SaveToJSON(graph, filePath);
+        }
+
+        internal Dictionary<string, Dictionary<string, bool>> GetClassCohesionGraph(CaDETClass caDetClass)
+        {
+            var methods = caDetClass.Members.Where(m => m.Type == CaDETMemberType.Method).ToList();
+            var allMethodsFieldsAndAccessors = GetAllMethodsFieldsAndAccessors(methods);
+            return BuildCohesionGraphConnectionMatrix(methods, allMethodsFieldsAndAccessors);
+        }
+
+        private void SaveToJSON(Dictionary<string, Dictionary<string, bool>> graph, string filePath)
+        {
+            var json = JsonSerializer.Serialize(graph, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(filePath, json);
+        }
+
+        private ISet<string> GetAllMethodsFieldsAndAccessors(List<CaDETMember> methods)
+        {
+            var retVal = new HashSet<string>();
+            foreach (var method in methods)
+            {
+                retVal.UnionWith(GetAllMethodsFieldsAndAccessors(method));
+            }
+            return retVal;
+        }
+
+        private static ISet<string> GetAllMethodsFieldsAndAccessors(CaDETMember method)
+        {
+            var retVal = new HashSet<string>();
+            retVal.UnionWith(method.GetAccessedOwnFields().Select(f => f.Name));
+            retVal.UnionWith(method.GetAccessedOwnAccessors().Select(a => a.Name));
+            retVal.UnionWith(method.InvokedMethods
+                .Where(i => i.Parent.Equals(method.Parent))
+                .Select(m => m.GetMethodNameWithParamTypes()));
+            return retVal;
+        }
+
+        private static Dictionary<string, Dictionary<string, bool>> BuildCohesionGraphConnectionMatrix(List<CaDETMember> methods, ISet<string> allMethodsFieldsAndAccessors)
+        {
+            // { "rowName": { "columnName" : connectionExists }
+            var retVal = new Dictionary<string, Dictionary<string, bool>>();
+            foreach (var method in methods)
+            {
+                retVal[method.GetMethodNameWithParamTypes()] = new Dictionary<string, bool>();
+                var allAccessedItems = GetAllMethodsFieldsAndAccessors(method);
+                foreach (var item in allMethodsFieldsAndAccessors)
+                {
+                    retVal[method.GetMethodNameWithParamTypes()][item] = allAccessedItems.Contains(item);
+                }
+            }
+
+            return retVal;
+        }
+    }
+}


### PR DESCRIPTION
The CaDETClass can be processed to determine its cohesion graph. The cohesion graph consists of nodes that map to fields, accessors, or methods. The connections between these nodes originate from a method and represent invocations of other methods or accesses to fields or accessors.

The cohesion graph is exported into a JSON so that it can be used by a graph community detector. It has the following structure:

> { "nameOfMethod": { "nameOfFieldOrAccessorOrOtherMethod": true/false (determining if an invocation or access exists) }
