### PR TITLE
Code metrics

### DIFF
--- a/CodeModel.Tests/DataFactories/CodeFactory.cs
+++ b/CodeModel.Tests/DataFactories/CodeFactory.cs
@@ -16,9 +16,9 @@ namespace CodeModel.Tests.DataFactories
             return Directory.GetFiles("../../../DataFactories/TestClasses/CodeParser/").Select(File.ReadAllText);
         }
 
-        public IEnumerable<string> GetClassForWOCMetric()
+        public IEnumerable<string> GetCaDETMetricsClasses()
         {
-            return ReadClassFromFile("../../../DataFactories/TestClasses/CaDETMetrics/ClassWOC.txt");
+            return Directory.GetFiles("../../../DataFactories/TestClasses/CaDETMetrics/").Select(File.ReadAllText);
         }
 
         public IEnumerable<string> GetEffectiveLinesOfCodeTest()

--- a/CodeModel.Tests/DataFactories/CodeFactory.cs
+++ b/CodeModel.Tests/DataFactories/CodeFactory.cs
@@ -16,6 +16,11 @@ namespace CodeModel.Tests.DataFactories
             return Directory.GetFiles("../../../DataFactories/TestClasses/CodeParser/").Select(File.ReadAllText);
         }
 
+        public IEnumerable<string> GetClassForWOCMetric()
+        {
+            return ReadClassFromFile("../../../DataFactories/TestClasses/CaDETMetrics/ClassWOC.txt");
+        }
+
         public IEnumerable<string> GetEffectiveLinesOfCodeTest()
         {
             return new[]

--- a/CodeModel.Tests/DataFactories/CodeFactory.cs
+++ b/CodeModel.Tests/DataFactories/CodeFactory.cs
@@ -274,6 +274,8 @@ namespace CodeModel.Tests.DataFactories
                     }
 
                     public double m2() {
+                        Class3 class3 = new Class3();
+                        class3.m1();
                         Class4 class4 = new Class4();
 
                         return class4.Hours;

--- a/CodeModel.Tests/DataFactories/TestClasses/CaDETMetrics/ClassWOC.txt
+++ b/CodeModel.Tests/DataFactories/TestClasses/CaDETMetrics/ClassWOC.txt
@@ -7,11 +7,11 @@ namespace DoctorApp.Model
     public class ClassWOC
     {
         public Appointment TestAppoint { get; set; }
-        public Appointment TestAppoint2 { get; }
+        public Appointment TestAppoint2 { get; private set; }
         public int TestNum;
         private List<Appointment> _appointments;
 
-        public AppointmentService()
+        public ClassWOC()
         {
             _appointments = new List<Appointment>();
         }

--- a/CodeModel.Tests/DataFactories/TestClasses/CaDETMetrics/ClassWOC.txt
+++ b/CodeModel.Tests/DataFactories/TestClasses/CaDETMetrics/ClassWOC.txt
@@ -1,0 +1,48 @@
+﻿using DoctorApp.Model.Data;
+using DoctorApp.Model.Data.DateR;
+using System;
+using System.Collections.Generic;
+namespace DoctorApp.Model
+{
+    public class ClassWOC
+    {
+        public Appointment TestAppoint { get; set; }
+        public Appointment TestAppoint2 { get; }
+        public int TestNum;
+        private List<Appointment> _appointments;
+
+        public AppointmentService()
+        {
+            _appointments = new List<Appointment>();
+        }
+
+        public DateRange DateRangeTest()
+        {
+            return null;
+        }
+
+        public Appointment FindAvailableAppointment(DateRange timeSpan)
+        {
+            foreach (Appointment a in _appointments)
+            {
+                    if (IsFree(a, timeSpan)) return a;
+            }
+            return null;
+        }
+
+        private boolean IsFree(Appointment a, DateRange timeSpan)
+        {
+            return true;
+        }
+
+        public static void Test() 
+        {
+            return;
+        }
+
+        public abstract void Test2() 
+        {
+            return;
+        }
+    }
+}

--- a/CodeModel.Tests/DataFactories/TestClasses/CaDETMetrics/HierarchyClasses.txt
+++ b/CodeModel.Tests/DataFactories/TestClasses/CaDETMetrics/HierarchyClasses.txt
@@ -1,0 +1,55 @@
+﻿namespace Hierarchy {
+	public class ParentClass {
+		private int _x;
+		public int y;
+		protected int a;
+		protected int b;
+		protected int c;
+
+		protected int D {get; set;}
+		protected int F {get; set;}
+		public int Z {get; set;}
+
+		protected void Method1() {
+			return;
+		}
+
+		protected void Method2() {
+			return;
+		}
+
+		protected void Method3() {
+			return;
+		}
+
+		private void Method4() {
+			return;
+		}
+
+		public void Method5() {
+			return;
+		}
+	}
+
+	public class ChildClass : ParentClass {
+		private int _f1;
+		public int f2;
+
+		public int Cnt {get; set;}
+
+		public void M1() {
+			Method1();
+			Method2();
+		}
+
+		public void M2() {
+			return;
+		}
+
+		public void M3() {
+			a = 5;
+			Method2();
+			_f1 = D;
+		}
+	}
+}

--- a/CodeModel.Tests/DataFactories/TestClasses/CaDETMetrics/HierarchyClasses.txt
+++ b/CodeModel.Tests/DataFactories/TestClasses/CaDETMetrics/HierarchyClasses.txt
@@ -51,5 +51,8 @@
 			Method2();
 			_f1 = D;
 		}
+		public override void Method5() {
+			var abc = 5;
+		}
 	}
 }

--- a/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
+++ b/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
@@ -569,5 +569,18 @@ namespace CodeModel.Tests.Unit.CaDETMetrics
             childClass.Metrics[CaDETMetric.BUR].ShouldBe(0.5);
             parentClass.Metrics[CaDETMetric.BUR].ShouldBe(0);
         }
+
+        [Fact]
+        public void Calculates_base_class_overriding_ratio()
+        {
+            CodeModelFactory factory = new CodeModelFactory();
+
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/CaDETMetrics/HierarchyClasses.txt")).Classes;
+            var childClass = classes.Find(c => c.Name.Equals("ChildClass"));
+            var parentClass = classes.Find(c => c.Name.Equals("ParentClass"));
+
+            childClass.Metrics[CaDETMetric.BOvR].ShouldBe(0.25);
+            parentClass.Metrics[CaDETMetric.BOvR].ShouldBe(0);
+        }
     }
 }

--- a/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
+++ b/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
@@ -546,5 +546,15 @@ namespace CodeModel.Tests.Unit.CaDETMetrics
             levelClass.Metrics[CaDETMetric.NOPP].ShouldBe(2);
             classWOC.Metrics[CaDETMetric.NOPP].ShouldBe(2);
         }
+
+        [Fact]
+        public void Calculates_weighted_methods_count_of_not_accessor_or_mutator_methods()
+        {
+            CodeModelFactory factory = new CodeModelFactory();
+
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/CaDETMetrics/Level.txt")).Classes;
+
+            classes.First().Metrics[CaDETMetric.WMCNAMM].ShouldBe(412);
+        }
     }
 }

--- a/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
+++ b/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
@@ -509,5 +509,14 @@ namespace CodeModel.Tests.Unit.CaDETMetrics
             gitClass.FindMember("CreateClassMemberBuilders1").Metrics[CaDETMetric.NOUW].ShouldBe(22);
             gitClass.FindMember("CreateClassMemberBuilders2").Metrics[CaDETMetric.NOUW].ShouldBe(33);
         }
+
+        [Fact]
+        public void Calculates_weight_of_class()
+        {
+            CodeModelFactory factory = new CodeModelFactory();
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetClassForWOCMetric()).Classes;
+
+            classes.First().Metrics[CaDETMetric.WOC].ShouldBe(0.75);
+        }
     }
 }

--- a/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
+++ b/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
@@ -514,9 +514,24 @@ namespace CodeModel.Tests.Unit.CaDETMetrics
         public void Calculates_weight_of_class()
         {
             CodeModelFactory factory = new CodeModelFactory();
-            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetClassForWOCMetric()).Classes;
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCaDETMetricsClasses()).Classes;
 
-            classes.First().Metrics[CaDETMetric.WOC].ShouldBe(0.75);
+            var wocClass = classes.Find(c => c.Name.Equals("ClassWOC"));
+
+            wocClass.Metrics[CaDETMetric.WOC].ShouldBe(0.75);
+        }
+
+        [Fact]
+        public void Calculates_number_of_public_attributes()
+        {
+            CodeModelFactory factory = new CodeModelFactory();
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCaDETMetricsClasses()).Classes;
+
+            var levelClass = classes.Find(c => c.Name.Equals("Level"));
+            var asepriteReader = classes.Find(c => c.Name.Equals("AsepriteReader"));
+
+            levelClass.Metrics[CaDETMetric.NOPA].ShouldBe(27);
+            asepriteReader.Metrics[CaDETMetric.NOPA].ShouldBe(0);
         }
     }
 }

--- a/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
+++ b/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
@@ -556,5 +556,18 @@ namespace CodeModel.Tests.Unit.CaDETMetrics
 
             classes.First().Metrics[CaDETMetric.WMCNAMM].ShouldBe(412);
         }
+
+        [Fact]
+        public void Calculates_base_class_usage_ratio()
+        {
+            CodeModelFactory factory = new CodeModelFactory();
+
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.ReadClassFromFile("../../../DataFactories/TestClasses/CaDETMetrics/HierarchyClasses.txt")).Classes;
+            var childClass = classes.Find(c => c.Name.Equals("ChildClass"));
+            var parentClass = classes.Find(c => c.Name.Equals("ParentClass"));
+
+            childClass.Metrics[CaDETMetric.BUR].ShouldBe(0.5);
+            parentClass.Metrics[CaDETMetric.BUR].ShouldBe(0);
+        }
     }
 }

--- a/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
+++ b/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
@@ -518,7 +518,7 @@ namespace CodeModel.Tests.Unit.CaDETMetrics
 
             var wocClass = classes.Find(c => c.Name.Equals("ClassWOC"));
 
-            wocClass.Metrics[CaDETMetric.WOC].ShouldBe(0.75);
+            wocClass.Metrics[CaDETMetric.WOC].ShouldBe(1);
         }
 
         [Fact]
@@ -532,6 +532,19 @@ namespace CodeModel.Tests.Unit.CaDETMetrics
 
             levelClass.Metrics[CaDETMetric.NOPA].ShouldBe(27);
             asepriteReader.Metrics[CaDETMetric.NOPA].ShouldBe(0);
+        }
+
+        [Fact]
+        public void Calculates_number_of_public_properties()
+        {
+            CodeModelFactory factory = new CodeModelFactory();
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetCaDETMetricsClasses()).Classes;
+
+            var levelClass = classes.Find(c => c.Name.Equals("Level"));
+            var classWOC = classes.Find(c => c.Name.Equals("ClassWOC"));
+
+            levelClass.Metrics[CaDETMetric.NOPP].ShouldBe(2);
+            classWOC.Metrics[CaDETMetric.NOPP].ShouldBe(2);
         }
     }
 }

--- a/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
+++ b/CodeModel.Tests/Unit/CaDETMetrics/MetricCalculationTests.cs
@@ -582,5 +582,21 @@ namespace CodeModel.Tests.Unit.CaDETMetrics
             childClass.Metrics[CaDETMetric.BOvR].ShouldBe(0.25);
             parentClass.Metrics[CaDETMetric.BOvR].ShouldBe(0);
         }
+
+        [Fact]
+        public void Calculates_access_of_import_data()
+        {
+            CodeModelFactory factory = new CodeModelFactory();
+
+            List<CaDETClass> classes = factory.CreateProject(TestDataFactory.GetATFDMultipleClassTexts()).Classes;
+
+            var class1member1 = classes.Find(c => c.Name.Equals("Class1")).FindMember("m1");
+            var class3member1 = classes.Find(c => c.Name.Equals("Class3")).FindMember("m1");
+            var class5member2 = classes.Find(c => c.Name.Equals("Class5")).FindMember("m2");
+
+            class1member1.Metrics[CaDETMetric.AID].ShouldBe(2);
+            class3member1.Metrics[CaDETMetric.AID].ShouldBe(1);
+            class5member2.Metrics[CaDETMetric.AID].ShouldBe(2);
+        }
     }
 }

--- a/CodeModel/CaDETModel/CodeItems/CaDETClass.cs
+++ b/CodeModel/CaDETModel/CodeItems/CaDETClass.cs
@@ -86,6 +86,12 @@ namespace CodeModel.CaDETModel.CodeItems
         {
             return Fields.Find(field => field.Name.Equals(name));
         }
+
+        public IEnumerable<CaDETMember> GetMethods()
+        {
+            return Members.Where(m => m.Type.Equals(CaDETMemberType.Method));
+        }
+
         public bool IsPartialClass()
         {
             return Modifiers.Any(m => m.Value == CaDETModifierValue.Partial);

--- a/CodeModel/CaDETModel/CodeItems/CaDETField.cs
+++ b/CodeModel/CaDETModel/CodeItems/CaDETField.cs
@@ -30,5 +30,10 @@ namespace CodeModel.CaDETModel.CodeItems
         {
             return Type.LinkedTypes;
         }
+
+        public bool HasModifier(CaDETModifierValue modifier)
+        {
+            return Modifiers.Find(m => m.Value.Equals(modifier)) != null;
+        }
     }
 }

--- a/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
+++ b/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
@@ -85,6 +85,11 @@ namespace CodeModel.CaDETModel.CodeItems
             return accessedOwnAccessors;
         }
 
+        public bool HasModifier(CaDETModifierValue modifier)
+        {
+            return Modifiers.Find(m => m.Value.Equals(modifier)) != null;
+        }
+
         public override bool Equals(object other)
         {
             if (!(other is CaDETMember otherMember)) return false;

--- a/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
+++ b/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
@@ -149,6 +149,12 @@
         /// </summary>
         WMCNAMM,
 
+        /// <summary>
+        /// BUR: Base class Usage Ratio, counts the number of inheritance-specific members used by the measured class, 
+        /// divided by the total number of inheritance-specific members from the base class
+        /// </summary>
+        BUR,
+
         #endregion
 
         #region MemberMetrics

--- a/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
+++ b/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
@@ -139,6 +139,11 @@
         /// </summary>
         NOPA,
 
+        /// <summary>
+        /// NOAM: Number Of Public Properties
+        /// </summary>
+        NOPP,
+
         #endregion
 
         #region MemberMetrics

--- a/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
+++ b/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
@@ -155,6 +155,12 @@
         /// </summary>
         BUR,
 
+        /// <summary>
+        /// BOvR: Base class Overriding Ratio, counts the number of methods of the measured class that override methods from the base class, 
+        /// divided by the total number of methods in the class
+        /// </summary>
+        BOvR,
+
         #endregion
 
         #region MemberMetrics

--- a/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
+++ b/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
@@ -134,9 +134,14 @@
         /// </summary>
         WOC,
 
-    #endregion
+        /// <summary>
+        /// NOPA: Number Of Public Attributes
+        /// </summary>
+        NOPA,
 
-    #region MemberMetrics
+        #endregion
+
+        #region MemberMetrics
         /// <summary>
         /// CYCLO - Cyclomatic complexity
         ///

--- a/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
+++ b/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
@@ -129,9 +129,14 @@
         /// </summary>
         NIC,
 
-        #endregion
+        /// <summary>
+        /// WOC: Weight Of a Class, counts the number of “functional” public methods divided by the total number of public members
+        /// </summary>
+        WOC,
 
-        #region MemberMetrics
+    #endregion
+
+    #region MemberMetrics
         /// <summary>
         /// CYCLO - Cyclomatic complexity
         ///

--- a/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
+++ b/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
@@ -261,7 +261,12 @@
         /// <summary>
         /// NOUW: Number of unique words
         /// </summary>
-        NOUW
+        NOUW,
+
+        /// <summary>
+        /// AID: Access to import data, counts attributes and methods (differs from ATFD which counts attributes and get/set methods)
+        /// </summary>
+        AID,
         #endregion
     }
 }

--- a/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
+++ b/CodeModel/CaDETModel/CodeItems/CaDETMetrics.cs
@@ -144,6 +144,11 @@
         /// </summary>
         NOPP,
 
+        /// <summary>
+        /// WMCNAMM: Weighted Methods Count of Not Accessor or Mutator Methods
+        /// </summary>
+        WMCNAMM,
+
         #endregion
 
         #region MemberMetrics

--- a/CodeModel/CodeParsers/CSharp/CaDETClassMetricCalculator.cs
+++ b/CodeModel/CodeParsers/CSharp/CaDETClassMetricCalculator.cs
@@ -41,7 +41,13 @@ namespace CodeModel.CodeParsers.CSharp
                 [CaDETMetric.WOC] = CountWeightOfClass(parsedClass),
                 [CaDETMetric.NOPA] = CountPublicAttributes(parsedClass),
                 [CaDETMetric.NOPP] = CountPublicProperties(parsedClass.Members),
+                [CaDETMetric.WMCNAMM] = GetWMCOfNotAccessorOrMuttatorMethods(parsedClass),
             };
+        }
+
+        private static double GetWMCOfNotAccessorOrMuttatorMethods(CaDETClass parsedClass)
+        {
+            return parsedClass.Members.Where(m => !m.Type.Equals(CaDETMemberType.Property)).Sum(m => m.Metrics[CaDETMetric.CYCLO]);
         }
 
         // Public attributes for NOPA metric do not include constants and static fields. (Object-oriented metrics in practice)

--- a/CodeModel/CodeParsers/CSharp/CaDETClassMetricCalculator.cs
+++ b/CodeModel/CodeParsers/CSharp/CaDETClassMetricCalculator.cs
@@ -47,117 +47,6 @@ namespace CodeModel.CodeParsers.CSharp
             };
         }
 
-        private static double GetBaseClassOverridingRatio(CaDETClass parsedClass)
-        {
-            if (parsedClass.Parent == null) return 0;
-            return (double)CountOverridingMethods(parsedClass) / GetNumberOfMethodsDeclared(parsedClass);
-        }
-
-        private static double CountOverridingMethods(CaDETClass parsedClass)
-        {
-            return FindMembersWithModifier(GetMethods(parsedClass.Members), CaDETModifierValue.Override).Count();
-        }
-
-        private static IEnumerable<CaDETMember> GetMethods(IEnumerable<CaDETMember> members)
-        {
-            return members.Where(m => m.Type.Equals(CaDETMemberType.Method));
-        }
-
-        private static double GetBaseClassUsageRatio(CaDETClass parsedClass)
-        {
-            if (parsedClass.Parent == null) return 0;
-            return (double) CountProtectedMembersUsed(parsedClass) / CountProtectedMembersInBaseClass(parsedClass.Parent);
-        }
-
-        private static int CountProtectedMembersInBaseClass(CaDETClass parent)
-        {
-            return FindFieldsWithModifier(parent.Fields, CaDETModifierValue.Protected).Count() + FindMembersWithModifier(parent.Members, CaDETModifierValue.Protected).Count();
-        }
-
-        private static int CountProtectedMembersUsed(CaDETClass parsedClass)
-        {
-            return CountAccessedInheritatedFields(parsedClass) + CountUsedInheritatedMethods(parsedClass);
-        }
-
-        private static int CountAccessedInheritatedFields(CaDETClass parsedClass)
-        {
-            var protectedParentFields = FindFieldsWithModifier(parsedClass.Parent.Fields, CaDETModifierValue.Protected);
-            var accessedFields = parsedClass.Members.SelectMany(m => m.AccessedFields);
-            var accessedInheritedFields = protectedParentFields.Select(f => f.Name).Intersect(accessedFields.Select(f => f.Name));
-            return accessedInheritedFields.Count();
-        }
-
-        private static int CountUsedInheritatedMethods(CaDETClass parsedClass)
-        {
-            var protectedParentMembers = FindMembersWithModifier(parsedClass.Parent.Members, CaDETModifierValue.Protected);
-            var invokedMethods = parsedClass.Members.SelectMany(m => m.InvokedMethods);
-            var accessedAccessors = parsedClass.Members.SelectMany(m => m.AccessedAccessors);
-            var usedMethods = invokedMethods.Union(accessedAccessors);
-            var usedInheritedMethods = protectedParentMembers.Select(m => m.Name).Intersect(usedMethods.Select(m => m.Name));
-            return usedInheritedMethods.Count();
-        }
-
-        private static double GetWMCOfNotAccessorOrMuttatorMethods(CaDETClass parsedClass)
-        {
-            return parsedClass.Members.Where(m => !m.Type.Equals(CaDETMemberType.Property)).Sum(m => m.Metrics[CaDETMetric.CYCLO]);
-        }
-
-        // Public attributes for NOPA metric do not include constants and static fields. (Object-oriented metrics in practice)
-        private static int CountPublicAttributes(CaDETClass parsedClass)
-        {
-            var publicFields = GetPublicFields(parsedClass.Fields);
-            var staticFields = (from field in publicFields
-                             from modifier in field.Modifiers
-                             where modifier.Value.Equals(CaDETModifierValue.Static)
-                             select field).ToList();
-            return publicFields.Where(f => !staticFields.Contains(f)).Count();
-        }
-
-        private static double CountWeightOfClass(CaDETClass parsedClass)
-        {
-            return (double)CountFunctionalPublicMethods(parsedClass.Members) / (CountPublicProperties(parsedClass.Members) + GetPublicFields(parsedClass.Fields).Count());
-        }
-
-        // Public fields for WOC metric do not include constants. (Object-oriented metrics in practice)
-        private static IEnumerable<CaDETField> GetPublicFields(List<CaDETField> fields)
-        {
-            var publicFields = FindFieldsWithModifier(fields, CaDETModifierValue.Public);
-            var constants = FindFieldsWithModifier(publicFields, CaDETModifierValue.Const);
-            return publicFields.Where(f => !constants.Contains(f));
-        }
-
-        private static IEnumerable<CaDETField> FindFieldsWithModifier(IEnumerable<CaDETField> fields, CaDETModifierValue modifierValue)
-        {
-            return (from field in fields
-                    from modifier in field.Modifiers
-                    where modifier.Value.Equals(modifierValue)
-                    select field);
-        }
-
-        private static int CountPublicProperties(IEnumerable<CaDETMember> members)
-        {
-            var properties = members.Where(m => m.Type.Equals(CaDETMemberType.Property));
-            var publicProperties = FindMembersWithModifier(properties, CaDETModifierValue.Public);
-            return publicProperties.Count();
-        }
-
-        // Functional public methods do not include get/set, constructor and abstract methods. (Object-oriented metrics in practice)
-        private static int CountFunctionalPublicMethods(List<CaDETMember> members)
-        {
-            var methods = GetMethods(members);
-            var publicMethods = FindMembersWithModifier(methods, CaDETModifierValue.Public);
-            var abstractMethods = FindMembersWithModifier(publicMethods, CaDETModifierValue.Abstract);
-            return publicMethods.Where(m => !abstractMethods.Contains(m)).Count();
-        }
-
-        private static IEnumerable<CaDETMember> FindMembersWithModifier(IEnumerable<CaDETMember> members, CaDETModifierValue modifierValue)
-        {
-            return (from member in members
-                    from modifier in member.Modifiers
-                    where modifier.Value.Equals(modifierValue)
-                    select member);
-        }
-
         private static int GetLinesOfCode(string code)
         {
             return code.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None).Length;
@@ -171,38 +60,34 @@ namespace CodeModel.CodeParsers.CSharp
             return parsedClass.Members.Sum(m => m.Metrics[CaDETMetric.MELOC]);
         }
 
-        /// <summary>
-        /// ATFD: Access To Foreign Data
-        /// DOI: 10.1109/ESEM.2009.5314231
-        /// </summary>
-        private static int GetAccessToForeignData(CaDETClass parsedClass)
+        private static int GetNumberOfMethodsDeclared(CaDETClass parsedClass)
         {
-            ISet<CaDETField> accessedExternalFields = new HashSet<CaDETField>();
-            ISet<CaDETMember> accessedExternalAccessors = new HashSet<CaDETMember>();
+            return parsedClass.GetMethods().Count();
+        }
 
-            foreach (var member in parsedClass.Members)
-            {
-                accessedExternalFields.UnionWith(member.AccessedFields.Where(f => !f.Parent.Equals(member.Parent)));
-                accessedExternalAccessors.UnionWith(member.AccessedAccessors.Where(a => !a.Parent.Equals(member.Parent)));
-            }
-
-            return accessedExternalAccessors.Count + accessedExternalFields.Count;
+        private static int GetNumberOfAttributesDefined(CaDETClass parsedClass)
+        {
+            //TODO: Probably should expand to include simple accessors that do not have a related field.
+            //TODO: It is C# specific, but this is the CSSharpMetricCalculator
+            return parsedClass.Fields.Count + parsedClass.Members.Count(m => m.IsFieldDefiningAccessor());
         }
 
         /// <summary>
-        /// ATFD: Access To Foreign Data Directly
-        /// DOI: 10.1145/1852786.1852797
+        /// WMC - Weighted Method Per Class
+        /// DOI: 10.1109/32.295895
         /// </summary>
-        private static double GetAccessToForeignDataDirectly(CaDETClass parsedClass)
+        private static double GetWeightedMethodPerClass(CaDETClass parsedClass)
         {
-            ISet<CaDETField> accessedExternalFields = new HashSet<CaDETField>();
+            return parsedClass.Members.Sum(method => method.Metrics[CaDETMetric.CYCLO]);
+        }
 
-            foreach (var member in parsedClass.Members)
-            {
-                accessedExternalFields.UnionWith(member.AccessedFields.Where(f => !f.Parent.Equals(member.Parent)));
-            }
-
-            return accessedExternalFields.Count;
+        /// <summary>
+        /// WMC - Weighted Method Per Class
+        /// DOI: 10.1109/32.295895, but using a different cyclo metric.
+        /// </summary>
+        private double GetWeightedMethodPerClassWithoutCase(CaDETClass parsedClass)
+        {
+            return parsedClass.Members.Sum(method => method.Metrics[CaDETMetric.CYCLO_SWITCH]);
         }
 
         private static double GetLackOfCohesionOfMethods(CaDETClass parsedClass)
@@ -212,11 +97,19 @@ namespace CodeModel.CodeParsers.CSharp
             if (maxCohesion == 0) return -1;
 
             double methodFieldAccess = 0;
-            foreach (var method in GetMethods(parsedClass.Members))
+            foreach (var method in parsedClass.GetMethods())
             {
                 methodFieldAccess += CountOwnFieldAndAccessorAccessed(parsedClass, method);
             }
-            return Math.Round(1 - methodFieldAccess/maxCohesion, 3);
+            return Math.Round(1 - methodFieldAccess / maxCohesion, 3);
+        }
+
+        private static int CountOwnFieldAndAccessorAccessed(CaDETClass parsedClass, CaDETMember method)
+        {
+            int counter = method.AccessedFields.Count(field => Enumerable.Contains(parsedClass.Fields, field));
+            counter += method.AccessedAccessors.Count(accessor => Enumerable.Contains(parsedClass.Members, accessor));
+
+            return counter;
         }
 
         /// <summary>
@@ -227,16 +120,16 @@ namespace CodeModel.CodeParsers.CSharp
         {
             var numberOfAttributes = GetNumberOfAttributesDefined(parsedClass);
             var numberOfMethods = GetNumberOfMethodsDeclared(parsedClass);
-          
+
             if (numberOfMethods == 0 || numberOfAttributes == 0) return 0;
             if (numberOfMethods == 1) return 0;
 
             double methodFieldAccess = 0;
-            foreach (var method in GetMethods(parsedClass.Members))
+            foreach (var method in parsedClass.GetMethods())
             {
                 methodFieldAccess += CountOwnFieldAndAccessorAccessed(parsedClass, method);
             }
-            return Math.Round((numberOfMethods - (methodFieldAccess/numberOfAttributes)) / (numberOfMethods - 1), 3);
+            return Math.Round((numberOfMethods - (methodFieldAccess / numberOfAttributes)) / (numberOfMethods - 1), 3);
         }
 
         /// <summary>
@@ -245,7 +138,7 @@ namespace CodeModel.CodeParsers.CSharp
         /// </summary>
         private static double GetLackOfCohesionOfMethods4(CaDETClass parsedClass)
         {
-            var methods = GetMethods(parsedClass.Members).ToList();
+            var methods = parsedClass.GetMethods().ToList();
 
             var numberOfMethodsThatAccessOwnFieldsOrMethods = CountNumberOfMethodsThatAccessToOwnFieldsOrMethods(parsedClass, methods);
             var numberOfMethodsThatShareAccessToFieldOrAccessor = CountNumberOfMethodsThatShareAccessToAFieldOrAccessor(methods);
@@ -297,11 +190,11 @@ namespace CodeModel.CodeParsers.CSharp
         private static double GetTightClassCohesion(CaDETClass parsedClass)
         {
             int N = GetNumberOfMethodsDeclared(parsedClass);
-           
+
             double NP = (N * (N - 1)) / 2;
             if (NP == 0) return -1;
 
-            var classMethods = GetMethods(parsedClass.Members).ToList();
+            var classMethods = parsedClass.GetMethods().ToList();
 
             return Math.Round(CountMethodPairsThatShareAccessToAFieldOrAccessor(classMethods) / NP, 2);
         }
@@ -312,12 +205,12 @@ namespace CodeModel.CodeParsers.CSharp
 
             for (var i = 0; i < classMethods.Count - 1; i++)
             {
-                for (var j = i+1; j < classMethods.Count; j++)
+                for (var j = i + 1; j < classMethods.Count; j++)
                 {
                     var firstMethod = classMethods[i];
                     var secondMethod = classMethods[j];
 
-                    if (firstMethod.GetAccessedOwnFields().Intersect(secondMethod.GetAccessedOwnFields()).Any() 
+                    if (firstMethod.GetAccessedOwnFields().Intersect(secondMethod.GetAccessedOwnFields()).Any()
                         || firstMethod.GetAccessedOwnAccessors().Intersect(secondMethod.GetAccessedOwnAccessors()).Any())
                     {
                         methodPairsThatShareAccessToAFieldOrAccessor++;
@@ -327,42 +220,22 @@ namespace CodeModel.CodeParsers.CSharp
             return methodPairsThatShareAccessToAFieldOrAccessor;
         }
 
-        private static int CountOwnFieldAndAccessorAccessed(CaDETClass parsedClass, CaDETMember method)
-        {
-            int counter = method.AccessedFields.Count(field => Enumerable.Contains(parsedClass.Fields, field));
-            counter += method.AccessedAccessors.Count(accessor => Enumerable.Contains(parsedClass.Members, accessor));
-
-            return counter;
-        }
-
         /// <summary>
-        /// WMC - Weighted Method Per Class
-        /// DOI: 10.1109/32.295895
+        /// ATFD: Access To Foreign Data
+        /// DOI: 10.1109/ESEM.2009.5314231
         /// </summary>
-        private static double GetWeightedMethodPerClass(CaDETClass parsedClass)
+        private static int GetAccessToForeignData(CaDETClass parsedClass)
         {
-            return parsedClass.Members.Sum(method => method.Metrics[CaDETMetric.CYCLO]);
-        }
+            ISet<CaDETField> accessedExternalFields = new HashSet<CaDETField>();
+            ISet<CaDETMember> accessedExternalAccessors = new HashSet<CaDETMember>();
 
-        /// <summary>
-        /// WMC - Weighted Method Per Class
-        /// DOI: 10.1109/32.295895, but using a different cyclo metric.
-        /// </summary>
-        private double GetWeightedMethodPerClassWithoutCase(CaDETClass parsedClass)
-        {
-            return parsedClass.Members.Sum(method => method.Metrics[CaDETMetric.CYCLO_SWITCH]);
-        }
+            foreach (var member in parsedClass.Members)
+            {
+                accessedExternalFields.UnionWith(member.AccessedFields.Where(f => !f.Parent.Equals(member.Parent)));
+                accessedExternalAccessors.UnionWith(member.AccessedAccessors.Where(a => !a.Parent.Equals(member.Parent)));
+            }
 
-        private static int GetNumberOfAttributesDefined(CaDETClass parsedClass)
-        {
-            //TODO: Probably should expand to include simple accessors that do not have a related field.
-            //TODO: It is C# specific, but this is the CSSharpMetricCalculator
-            return parsedClass.Fields.Count + parsedClass.Members.Count(m => m.IsFieldDefiningAccessor());
-        }
-
-        private static int GetNumberOfMethodsDeclared(CaDETClass parsedClass)
-        {
-            return GetMethods(parsedClass.Members).Count();
+            return accessedExternalAccessors.Count + accessedExternalFields.Count;
         }
 
         // Implementation based on https://github.com/mauricioaniche/ck
@@ -433,6 +306,18 @@ namespace CodeModel.CodeParsers.CSharp
             return uniqueDependencies.Count();
         }
 
+        //Implementation based on https://objectscriptquality.com/docs/metrics/depth-inheritance-tree
+        private static int CountInheritanceLevel(CaDETClass parsedClass)
+        {
+            CaDETClass parent = parsedClass.Parent;
+            if (parent == null)
+            {
+                return 0;
+            }
+
+            return 1 + CountInheritanceLevel(parent);
+        }
+
         //Implementation based on http://www.theijes.com/papers/v5-i6/C05014019.pdf
         private static int CountClassCoupling(CaDETClass parsedClass)
         {
@@ -446,21 +331,122 @@ namespace CodeModel.CodeParsers.CSharp
             return uniqueDependencies.Count();
         }
 
-        //Implementation based on https://objectscriptquality.com/docs/metrics/depth-inheritance-tree
-        private static int CountInheritanceLevel(CaDETClass parsedClass)
+        /// <summary>
+        /// ATFD: Access To Foreign Data Directly
+        /// DOI: 10.1145/1852786.1852797
+        /// </summary>
+        private static double GetAccessToForeignDataDirectly(CaDETClass parsedClass)
         {
-            CaDETClass parent = parsedClass.Parent;
-            if (parent == null)
+            ISet<CaDETField> accessedExternalFields = new HashSet<CaDETField>();
+
+            foreach (var member in parsedClass.Members)
             {
-                return 0;
+                accessedExternalFields.UnionWith(member.AccessedFields.Where(f => !f.Parent.Equals(member.Parent)));
             }
 
-            return 1 + CountInheritanceLevel(parent);
+            return accessedExternalFields.Count;
         }
 
         private static double CountInnerClasses(CaDETClass parsedClass)
         {
             return parsedClass.InnerClasses.Count;
+        }
+
+        private static double CountWeightOfClass(CaDETClass parsedClass)
+        {
+            return (double)CountFunctionalPublicMethods(parsedClass) / (CountPublicProperties(parsedClass.Members) + GetPublicFields(parsedClass.Fields).Count());
+        }
+
+        // Functional public methods do not include get/set, constructor and abstract methods. (Object-oriented metrics in practice)
+        private static int CountFunctionalPublicMethods(CaDETClass parsedClass)
+        {
+            var methods = parsedClass.GetMethods();
+            var publicMethods = FindMembersWithModifier(methods, CaDETModifierValue.Public);
+            var abstractMethods = FindMembersWithModifier(publicMethods, CaDETModifierValue.Abstract);
+            return publicMethods.Where(m => !abstractMethods.Contains(m)).Count();
+        }
+
+        private static IEnumerable<CaDETMember> FindMembersWithModifier(IEnumerable<CaDETMember> members, CaDETModifierValue modifierValue)
+        {
+            return members.Where(m => m.HasModifier(modifierValue));
+        }
+
+        // Public attributes for NOPA metric do not include constants and static fields. (Object-oriented metrics in practice)
+        private static int CountPublicAttributes(CaDETClass parsedClass)
+        {
+            var publicFields = GetPublicFields(parsedClass.Fields);
+            var staticFields = publicFields.Where(f => f.HasModifier(CaDETModifierValue.Static));
+            return publicFields.Where(f => !staticFields.Contains(f)).Count();
+        }
+
+        private static int CountPublicProperties(IEnumerable<CaDETMember> members)
+        {
+            var properties = members.Where(m => m.Type.Equals(CaDETMemberType.Property));
+            var publicProperties = FindMembersWithModifier(properties, CaDETModifierValue.Public);
+            return publicProperties.Count();
+        }
+
+        // Public fields for WOC metric do not include constants. (Object-oriented metrics in practice)
+        private static IEnumerable<CaDETField> GetPublicFields(List<CaDETField> fields)
+        {
+            var publicFields = FindFieldsWithModifier(fields, CaDETModifierValue.Public);
+            var constants = FindFieldsWithModifier(publicFields, CaDETModifierValue.Const);
+            return publicFields.Where(f => !constants.Contains(f));
+        }
+
+        private static IEnumerable<CaDETField> FindFieldsWithModifier(IEnumerable<CaDETField> fields, CaDETModifierValue modifierValue)
+        {
+            return fields.Where(f => f.HasModifier(modifierValue));
+        }
+
+        private static double GetWMCOfNotAccessorOrMuttatorMethods(CaDETClass parsedClass)
+        {
+            return parsedClass.Members.Where(m => !m.Type.Equals(CaDETMemberType.Property)).Sum(m => m.Metrics[CaDETMetric.CYCLO]);
+        }
+
+        private static double GetBaseClassUsageRatio(CaDETClass parsedClass)
+        {
+            if (parsedClass.Parent == null) return 0;
+            return (double)CountProtectedMembersUsed(parsedClass) / CountProtectedMembersInBaseClass(parsedClass.Parent);
+        }
+
+        private static int CountProtectedMembersUsed(CaDETClass parsedClass)
+        {
+            return CountAccessedInheritatedFields(parsedClass) + CountUsedInheritatedMethods(parsedClass);
+        }
+
+        private static int CountAccessedInheritatedFields(CaDETClass parsedClass)
+        {
+            var protectedParentFields = FindFieldsWithModifier(parsedClass.Parent.Fields, CaDETModifierValue.Protected);
+            var accessedFields = parsedClass.Members.SelectMany(m => m.AccessedFields);
+            var accessedInheritedFields = protectedParentFields.Select(f => f.Name).Intersect(accessedFields.Select(f => f.Name));
+            return accessedInheritedFields.Count();
+        }
+
+        private static int CountUsedInheritatedMethods(CaDETClass parsedClass)
+        {
+            var protectedParentMembers = FindMembersWithModifier(parsedClass.Parent.Members, CaDETModifierValue.Protected);
+            var invokedMethods = parsedClass.Members.SelectMany(m => m.InvokedMethods);
+            var accessedAccessors = parsedClass.Members.SelectMany(m => m.AccessedAccessors);
+            var usedMethods = invokedMethods.Union(accessedAccessors);
+            var usedInheritedMethods = protectedParentMembers.Select(m => m.Name).Intersect(usedMethods.Select(m => m.Name));
+            return usedInheritedMethods.Count();
+        }
+
+        private static int CountProtectedMembersInBaseClass(CaDETClass parent)
+        {
+            return FindFieldsWithModifier(parent.Fields, CaDETModifierValue.Protected).Count() + FindMembersWithModifier(parent.Members, CaDETModifierValue.Protected).Count();
+        }
+
+        private static double GetBaseClassOverridingRatio(CaDETClass parsedClass)
+        {
+            if (parsedClass.Parent == null) return 0;
+            return (double)CountOverridingMethods(parsedClass) / GetNumberOfMethodsDeclared(parsedClass);
+        }
+
+        private static double CountOverridingMethods(CaDETClass parsedClass)
+        {
+            return FindMembersWithModifier(parsedClass.GetMethods(), CaDETModifierValue.Override).Count();
         }
     }
 }

--- a/CodeModel/CodeParsers/CSharp/CaDETClassMetricCalculator.cs
+++ b/CodeModel/CodeParsers/CSharp/CaDETClassMetricCalculator.cs
@@ -40,6 +40,7 @@ namespace CodeModel.CodeParsers.CSharp
                 [CaDETMetric.NIC] = CountInnerClasses(parsedClass),
                 [CaDETMetric.WOC] = CountWeightOfClass(parsedClass),
                 [CaDETMetric.NOPA] = CountPublicAttributes(parsedClass),
+                [CaDETMetric.NOPP] = CountPublicProperties(parsedClass.Members),
             };
         }
 
@@ -56,7 +57,7 @@ namespace CodeModel.CodeParsers.CSharp
 
         private static double CountWeightOfClass(CaDETClass parsedClass)
         {
-            return (double)CountFunctionalPublicMethods(parsedClass.Members) / (CountGetSetMethods(parsedClass.Members) + GetPublicFields(parsedClass.Fields).Count());
+            return (double)CountFunctionalPublicMethods(parsedClass.Members) / (CountPublicProperties(parsedClass.Members) + GetPublicFields(parsedClass.Fields).Count());
         }
 
         // Public fields for WOC metric do not include constants. (Object-oriented metrics in practice)
@@ -75,11 +76,11 @@ namespace CodeModel.CodeParsers.CSharp
                     select field);
         }
 
-        private static int CountGetSetMethods(IEnumerable<CaDETMember> members)
+        private static int CountPublicProperties(IEnumerable<CaDETMember> members)
         {
             var properties = members.Where(m => m.Type.Equals(CaDETMemberType.Property));
             var publicProperties = FindMembersWithModifier(properties, CaDETModifierValue.Public);
-            return publicProperties.Where(m => m.SourceCode.Contains("get;")).Count() + publicProperties.Where(m => m.SourceCode.Contains("set;")).Count();
+            return publicProperties.Count();
         }
 
         // Functional public methods do not include get/set, constructor and abstract methods. (Object-oriented metrics in practice)

--- a/CodeModel/CodeParsers/CSharp/CaDETMemberMetricCalculator.cs
+++ b/CodeModel/CodeParsers/CSharp/CaDETMemberMetricCalculator.cs
@@ -37,15 +37,6 @@ namespace CodeModel.CodeParsers.CSharp
             };
         }
 
-        private static int CountAccessOfImportData(CaDETMember member)
-        {
-            var accessedExternalFields = member.AccessedFields.Where(f => !f.Parent.Equals(member.Parent));
-            var accessedExternalAccessors = member.AccessedAccessors.Where(a => !a.Parent.Equals(member.Parent));
-            var usedExternalMethods = member.InvokedMethods.Where(m => !m.Parent.Equals(member.Parent));
-
-            return accessedExternalAccessors.Count() + accessedExternalFields.Count() + usedExternalMethods.Count();
-        }
-
         /// <summary>
         /// DOI: 10.1109/MALTESQUE.2017.7882011
         /// </summary>
@@ -457,5 +448,13 @@ namespace CodeModel.CodeParsers.CSharp
             return keywords;
         }
 
+        private static int CountAccessOfImportData(CaDETMember member)
+        {
+            var totalAccessedExternalFields = member.AccessedFields.Count(f => !f.Parent.Equals(member.Parent));
+            var totalAccessedExternalAccessors = member.AccessedAccessors.Count(a => !a.Parent.Equals(member.Parent));
+            var totalUsedExternalMethods = member.InvokedMethods.Count(m => !m.Parent.Equals(member.Parent));
+
+            return totalAccessedExternalFields + totalAccessedExternalAccessors + totalUsedExternalMethods;
+        }
     }
 }

--- a/CodeModel/CodeParsers/CSharp/CaDETMemberMetricCalculator.cs
+++ b/CodeModel/CodeParsers/CSharp/CaDETMemberMetricCalculator.cs
@@ -32,8 +32,18 @@ namespace CodeModel.CodeParsers.CSharp
                 [CaDETMetric.NOPE] = CountNumberOfParenthesizedExpressions(member),
                 [CaDETMetric.NOLE] = CountNumberOfLambdaExpressions(member),
                 [CaDETMetric.MMNB] = CountMaxNestedBlocks(member),
-                [CaDETMetric.NOUW] = CountNumberOfUniqueWords(member)
+                [CaDETMetric.NOUW] = CountNumberOfUniqueWords(member),
+                [CaDETMetric.AID] = CountAccessOfImportData(method)
             };
+        }
+
+        private static int CountAccessOfImportData(CaDETMember member)
+        {
+            var accessedExternalFields = member.AccessedFields.Where(f => !f.Parent.Equals(member.Parent));
+            var accessedExternalAccessors = member.AccessedAccessors.Where(a => !a.Parent.Equals(member.Parent));
+            var usedExternalMethods = member.InvokedMethods.Where(m => !m.Parent.Equals(member.Parent));
+
+            return accessedExternalAccessors.Count() + accessedExternalFields.Count() + usedExternalMethods.Count();
         }
 
         /// <summary>


### PR DESCRIPTION
- [x] **WOC - Weight Of a Class**
From book '_Object-oriented metrics in practice_':
![image](https://user-images.githubusercontent.com/15254876/131647694-a9cd05de-fa3b-4e48-8baf-34c618e7c0ab.png)

- [x] **AID - Access of Import Data** (Counts attributes and methods. Differs from ATFD which counts attributes and get/set methods.)
- [x] **NOPA - Number Of Public Attributes**
From book '_Object-oriented metrics in practice_':
![image](https://user-images.githubusercontent.com/15254876/131657916-457005f9-fd0c-499b-a7ac-40c2f4f2b7ac.png)

- [x] **NOPP - Number Of Public Properties** (A simpler version of the metric **NOAM - Number Of Accessor Methods** (getter and setter), due to the current CaDET model implementation on the Platform)
Our implementation: Ignore the exact number of public getters and setters, and count only public properties.
NOAM from book '_Object-oriented metrics in practice_':
![image](https://user-images.githubusercontent.com/15254876/131668635-bfd4f754-8e45-4330-86b1-39d8c3711798.png)

- [x] **WMCNAMM - Weighted Methods Count of Not Accessor or Mutator Methods** (The sum of complexity of the methods that are defined in the class, and are not accessor or mutator methods. We compute the complexity with the Cyclomatic Complexity metric (CYCLO))
- [x] **BUR - Base class Usage Ratio** (The number of inheritance-specific members used by the measured class divided by the total number of inheritance-specific members from the base class.)
- [x] **BOvR - Base class Overriding Ratio** (The number of methods of the measured class that override methods from base class, divided by the total number of methods in the class.)
